### PR TITLE
Add database comparison resources documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-35-0c87e78a
+Your prepared working directory: /tmp/gh-issue-solver-1760621670036
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-35-0c87e78a
-Your prepared working directory: /tmp/gh-issue-solver-1760621670036
-
-Proceed.

--- a/doc/articles/database-comparison-resources.md
+++ b/doc/articles/database-comparison-resources.md
@@ -1,0 +1,145 @@
+# Database Comparison Resources
+
+## Overview
+
+This document provides a curated list of websites and services that compare database management systems (DBMS) worldwide. These resources help developers, architects, and decision-makers evaluate and choose appropriate database solutions for their projects.
+
+## Major Comparison Services
+
+### DB-Engines (db-engines.com)
+
+**Website:** https://db-engines.com/
+
+**Description:** DB-Engines is the most comprehensive knowledge base and ranking platform for database management systems. It tracks over 425 database systems and provides detailed comparisons.
+
+**Key Features:**
+- **Monthly Rankings:** Popularity rankings updated monthly based on multiple factors
+- **Side-by-Side Comparisons:** Detailed property comparisons between database systems
+- **Database Encyclopedia:** Explanations of database terms and concepts
+- **Trend Analysis:** Historical popularity trends and statistics
+- **System Profiles:** Detailed information about each DBMS including:
+  - Database model (relational, document, key-value, graph, etc.)
+  - Implementation language
+  - Operating system support
+  - Licensing and pricing
+  - API and query languages
+  - Transaction support and concurrency
+  - Replication and sharding capabilities
+
+**Ranking Methodology:**
+- Number of mentions on websites (Google search results)
+- General interest in the system (Google Trends)
+- Technical discussions (Stack Overflow questions)
+- Job market demand (job postings)
+- Professional network profiles (LinkedIn)
+
+**Top Database Systems (as per latest ranking):**
+1. Oracle
+2. MySQL
+3. Microsoft SQL Server
+4. PostgreSQL
+5. MongoDB
+
+### Wikipedia Comparisons
+
+**Relational DBMS Comparison:** https://en.wikipedia.org/wiki/Comparison_of_relational_database_management_systems
+
+**Description:** Wikipedia provides detailed technical comparison tables for relational database management systems.
+
+**Key Features:**
+- General information (vendor, license, latest version)
+- Operating system support matrix
+- Fundamental features comparison
+- SQL compliance and extensions
+- Programming language support
+- Data types and constraints
+- Indexing and partitioning capabilities
+
+### Red9 Database Rankings
+
+**Website:** https://red9.com/database-popularity-ranking/
+
+**Description:** Similar to DB-Engines, Red9 provides monthly updated popularity rankings for database management systems.
+
+**Ranking Methodology:**
+- Search engine results and mentions
+- Technical discussions from Stack Overflow
+- Job postings from multiple platforms (Stack Overflow, Dice, Monster.com, LinkedIn Jobs)
+
+### Academic and Technical Resources
+
+**KeyCDN Database Guide:** https://www.keycdn.com/blog/popular-databases
+
+**Description:** Comprehensive guide covering pros and cons of popular databases including:
+- MySQL
+- PostgreSQL
+- MongoDB
+- Redis
+- Cassandra
+- MariaDB
+- Oracle
+- Microsoft SQL Server
+
+## Database Categories
+
+Modern database comparison resources typically categorize databases into several types:
+
+1. **Relational Databases (RDBMS)**
+   - Traditional SQL databases
+   - Examples: Oracle, MySQL, PostgreSQL, Microsoft SQL Server
+
+2. **Document Stores**
+   - NoSQL databases storing data as documents
+   - Examples: MongoDB, CouchDB, Couchbase
+
+3. **Key-Value Stores**
+   - Simple key-value pair storage
+   - Examples: Redis, Memcached, Amazon DynamoDB
+
+4. **Graph Databases**
+   - Optimized for graph-structured data
+   - Examples: Neo4j, ArangoDB, OrientDB
+
+5. **Wide Column Stores**
+   - Columnar storage for big data
+   - Examples: Apache Cassandra, HBase, ScyllaDB
+
+6. **Time Series Databases**
+   - Optimized for time-stamped data
+   - Examples: InfluxDB, TimescaleDB, Prometheus
+
+7. **Search Engines**
+   - Full-text search and analytics
+   - Examples: Elasticsearch, Solr, Sphinx
+
+## Links Platform Context
+
+Links Platform is built on an **associative model of data** using doublets (pairs) as the fundamental storage unit. This approach differs from traditional database models:
+
+- **Traditional RDBMS:** Table-based with rows and columns
+- **Document Stores:** JSON-like nested documents
+- **Graph Databases:** Nodes and edges with properties
+- **Links Platform:** Pure associative links (doublets/triplets)
+
+The associative model provides:
+- Maximum flexibility in data structure
+- Native support for graph-like relationships
+- Uniform storage mechanism for any data type
+- Efficient representation of sequences and hierarchies
+
+## Conclusion
+
+The database comparison landscape is well-served by resources like DB-Engines, which has become the industry standard for tracking database popularity and features. These resources help the community make informed decisions when selecting database technologies.
+
+For Links Platform, which represents a novel approach with its associative data model, these comparison sites provide valuable context for understanding how it relates to and differs from mainstream database systems.
+
+## References
+
+1. DB-Engines: https://db-engines.com/
+2. Wikipedia RDBMS Comparison: https://en.wikipedia.org/wiki/Comparison_of_relational_database_management_systems
+3. Red9 Rankings: https://red9.com/database-popularity-ranking/
+4. Links Platform: https://github.com/linksplatform
+
+---
+
+*Last updated: 2025-10-16*


### PR DESCRIPTION
## Summary

This PR addresses issue #35 by providing a comprehensive document listing major database comparison services and resources.

### What was found

The issue requested finding a service/website where "All World Databases" are compared. Research revealed that such services already exist, with **DB-Engines (https://db-engines.com/)** being the industry-standard resource.

### Changes Made

- Created `doc/articles/database-comparison-resources.md` documenting:
  - **DB-Engines**: The most comprehensive database ranking and comparison platform tracking 425+ database systems
  - **Wikipedia Comparisons**: Detailed technical comparison tables for RDBMS
  - **Red9 Rankings**: Alternative database popularity rankings
  - **Database Categories**: Overview of different database types (Relational, Document, Key-Value, Graph, etc.)
  - **Links Platform Context**: How Links Platform's associative model relates to traditional databases

### Key Findings

**DB-Engines** provides:
- Monthly popularity rankings based on search trends, Stack Overflow discussions, job postings, and professional networks
- Side-by-side feature comparisons
- Detailed system profiles covering database models, licensing, APIs, transaction support, and scalability features
- Historical trend analysis

The document also contextualizes Links Platform's unique associative data model within the broader database landscape.

Fixes #35

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)