### PR TITLE
Add snapshot logging feature for transaction logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-46-bd44d2be
-Your prepared working directory: /tmp/gh-issue-solver-1760623773168
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-46-bd44d2be
+Your prepared working directory: /tmp/gh-issue-solver-1760623773168
+
+Proceed.

--- a/Platform/Platform.Examples/LinksSnapshotLogger.cs
+++ b/Platform/Platform.Examples/LinksSnapshotLogger.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using Platform.Numbers;
+using Platform.Data;
+using Platform.Data.Doublets;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Provides functionality to push a snapshot of all existing links to a transaction log.
+    /// Предоставляет функциональность для выгрузки снимка всех существующих связей в лог транзакций.
+    /// </summary>
+    /// <remarks>
+    /// This utility addresses issue #46: allowing to push existing database links to transaction log
+    /// when logging is enabled on an already populated database.
+    /// Эта утилита решает проблему #46: позволяет выгрузить существующие связи БД в лог транзакций,
+    /// когда логирование включается на уже заполненной базе данных.
+    /// </remarks>
+    public class LinksSnapshotLogger<TLink>
+    {
+        private static readonly TLink _zero = default;
+        private static readonly TLink _one = Arithmetic.Increment(_zero);
+
+        private readonly ILinks<TLink> _links;
+
+        /// <summary>
+        /// Creates a new instance of LinksSnapshotLogger.
+        /// Создаёт новый экземпляр LinksSnapshotLogger.
+        /// </summary>
+        /// <param name="links">The links storage to create snapshot from. Хранилище связей для создания снимка.</param>
+        public LinksSnapshotLogger(ILinks<TLink> links)
+        {
+            _links = links ?? throw new ArgumentNullException(nameof(links));
+        }
+
+        /// <summary>
+        /// Pushes a snapshot of all existing links to the specified log stream.
+        /// Each link is written as a Create operation that can be replayed to restore the database.
+        /// Выгружает снимок всех существующих связей в указанный поток лога.
+        /// Каждая связь записывается как операция Create, которая может быть воспроизведена для восстановления БД.
+        /// </summary>
+        /// <param name="logStream">The stream to write the snapshot to. Поток для записи снимка.</param>
+        /// <returns>The number of links written to the snapshot. Количество связей записанных в снимок.</returns>
+        public TLink PushSnapshot(Stream logStream)
+        {
+            if (logStream == null)
+            {
+                throw new ArgumentNullException(nameof(logStream));
+            }
+
+            var writer = new StreamWriter(logStream, System.Text.Encoding.UTF8, 4096, leaveOpen: true);
+            try
+            {
+                writer.AutoFlush = true;
+
+                var constants = _links.Constants;
+                var count = _zero;
+
+                // Write snapshot header
+                writer.WriteLine($"# Snapshot Start - {DateTime.UtcNow:O}");
+                writer.WriteLine($"# Total links in database: {_links.Count()}");
+
+                // Iterate through all links
+                _links.Each(link =>
+                {
+                    var index = link[constants.IndexPart];
+
+                    // Skip the null/void link (index 0 or constants.Null)
+                    if (!index.Equals(constants.Null) && !index.Equals(_zero))
+                    {
+                        var source = link[constants.SourcePart];
+                        var target = link[constants.TargetPart];
+
+                        // Write in the same format as LoggingDecorator would write Create operations
+                        writer.WriteLine($"Create. Before: {constants.Null}: {constants.Null}->{constants.Null}. After: {index}: {source}->{target}");
+
+                        count = Arithmetic.Add(count, _one);
+                    }
+
+                    return constants.Continue;
+                });
+
+                // Write snapshot footer
+                writer.WriteLine($"# Snapshot End - {count} links written");
+                writer.Flush();
+
+                return count;
+            }
+            finally
+            {
+                writer?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Pushes a snapshot to a file at the specified path.
+        /// Выгружает снимок в файл по указанному пути.
+        /// </summary>
+        /// <param name="logFilePath">The path to the log file. Путь к файлу лога.</param>
+        /// <returns>The number of links written to the snapshot. Количество связей записанных в снимок.</returns>
+        public TLink PushSnapshotToFile(string logFilePath)
+        {
+            using (var fileStream = new FileStream(logFilePath, FileMode.Append, FileAccess.Write, FileShare.Read))
+            {
+                return PushSnapshot(fileStream);
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/LinksSnapshotLoggerCLI.cs
+++ b/Platform/Platform.Examples/LinksSnapshotLoggerCLI.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Platform.Data;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Generic;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Command-line interface example demonstrating snapshot logging functionality.
+    /// Пример интерфейса командной строки, демонстрирующий функциональность логирования снимков.
+    /// </summary>
+    /// <remarks>
+    /// This example demonstrates the solution to issue #46: pushing existing database links
+    /// to a transaction log, enabling full database recovery from the log.
+    /// Этот пример демонстрирует решение проблемы #46: выгрузка существующих связей БД
+    /// в лог транзакций, позволяющая полное восстановление БД из лога.
+    /// </remarks>
+    public class LinksSnapshotLoggerCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            if (args.Length < 2)
+            {
+                PrintUsage();
+                return;
+            }
+
+            var dbPath = args[0];
+            var logPath = args[1];
+
+            try
+            {
+                Console.WriteLine($"Opening database: {dbPath}");
+                Console.WriteLine($"Target log file: {logPath}");
+                Console.WriteLine();
+
+                using (var links = new UnitedMemoryLinks<ulong>(dbPath))
+                {
+                    var totalLinks = links.Count();
+                    Console.WriteLine($"Database contains {totalLinks} links");
+
+                    var snapshotLogger = new LinksSnapshotLogger<ulong>(links);
+
+                    Console.WriteLine("Pushing snapshot to transaction log...");
+                    var snapshotCount = snapshotLogger.PushSnapshotToFile(logPath);
+
+                    Console.WriteLine($"✓ Successfully wrote {snapshotCount} links to {logPath}");
+                    Console.WriteLine();
+                    Console.WriteLine("The transaction log can now be used to fully restore the database.");
+                    Console.WriteLine("Any future changes can be logged using LoggingDecorator (Platform.Data.Doublets 0.7+)");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                Console.Error.WriteLine(ex.StackTrace);
+                Environment.Exit(1);
+            }
+        }
+
+        private void PrintUsage()
+        {
+            Console.WriteLine("LinksSnapshotLogger - Push database snapshot to transaction log");
+            Console.WriteLine();
+            Console.WriteLine("Usage:");
+            Console.WriteLine("  LinksSnapshotLogger <database-path> <log-file-path>");
+            Console.WriteLine();
+            Console.WriteLine("Arguments:");
+            Console.WriteLine("  database-path    Path to the links database file (e.g., db.links)");
+            Console.WriteLine("  log-file-path    Path to the transaction log file (will be created/appended)");
+            Console.WriteLine();
+            Console.WriteLine("Example:");
+            Console.WriteLine("  LinksSnapshotLogger ./db.links ./transaction.log");
+            Console.WriteLine();
+            Console.WriteLine("Description:");
+            Console.WriteLine("  This tool creates a snapshot of all existing links in the database and");
+            Console.WriteLine("  writes them to a transaction log in the same format as LoggingDecorator.");
+            Console.WriteLine("  This allows enabling transaction logging on existing databases while");
+            Console.WriteLine("  preserving the ability to fully restore the database from the log.");
+            Console.WriteLine();
+            Console.WriteLine("  Issue: https://github.com/konard/LinksPlatform/issues/46");
+        }
+    }
+}

--- a/doc/snapshot-feature-proposal.md
+++ b/doc/snapshot-feature-proposal.md
@@ -1,0 +1,109 @@
+# Transaction Log Snapshot Feature Proposal
+
+## Issue Reference
+This document addresses issue [#46](https://github.com/konard/LinksPlatform/issues/46): "Allow to push Links Data Snapshot to Transaction Log"
+
+## Problem Statement
+
+Currently, the `LoggingDecorator` in `Platform.Data.Doublets` only logs **new** changes to the database (Create, Update, Delete operations). When transaction logging is enabled on an existing database that already contains data, the log only captures future changes.
+
+This creates a problem: if you need to restore the database from the transaction log, you cannot fully reconstruct it because the initial state (all links that existed before logging was enabled) is not in the log.
+
+## Proposed Solution
+
+Add a `PushSnapshot()` method to the `LoggingDecorator` class that writes all existing links to the transaction log as Create operations. This creates a "snapshot" of the database at the moment logging is enabled.
+
+### Implementation
+
+The feature should be implemented in the `linksplatform/Data.Doublets` repository by adding a new method to the `LoggingDecorator<TLinkAddress>` class:
+
+```csharp
+/// <summary>
+/// Pushes a snapshot of all existing links to the transaction log.
+/// This allows restoring the database to its current state from the log.
+/// Выгружает снимок всех существующих связей в лог транзакций.
+/// Это позволяет восстановить базу данных в её текущем состоянии из лога.
+/// </summary>
+/// <returns>The number of links written to the snapshot.</returns>
+public TLinkAddress PushSnapshot()
+{
+    var count = TLinkAddress.Zero;
+
+    // Write snapshot header to log
+    _logStreamWriter.WriteLine("# Snapshot Start");
+
+    // Iterate through all existing links
+    _links.Each(null, link =>
+    {
+        // Skip the null/void link (index 0)
+        if (link[_constants.IndexPart] != _constants.Null)
+        {
+            // Write each link as a Create operation
+            _logStreamWriter.WriteLine($"Create. Before: {_constants.Null}: {_constants.Null}->{_constants.Null}. After: {new Link<TLinkAddress>(values: link)}");
+            count++;
+        }
+        return _constants.Continue;
+    });
+
+    // Write snapshot footer to log
+    _logStreamWriter.WriteLine("# Snapshot End");
+    _logStreamWriter.Flush();
+
+    return count;
+}
+```
+
+### Usage Example
+
+```csharp
+// Create a database and populate it with data
+using (var memoryAdapter = new UnitedMemoryLinks<ulong>("db.links"))
+{
+    var links = memoryAdapter;
+    var link1 = links.Create();
+    var link2 = links.Create();
+    var link3 = links.Create(link1, link2);
+}
+
+// Later, enable transaction logging and push snapshot
+using (var memoryAdapter = new UnitedMemoryLinks<ulong>("db.links"))
+using (var logStream = new FileStream("transaction.log", FileMode.Create))
+{
+    var loggingDecorator = new LoggingDecorator<ulong>(memoryAdapter, logStream);
+
+    // Push snapshot of all existing links
+    var snapshotCount = loggingDecorator.PushSnapshot();
+    Console.WriteLine($"Pushed {snapshotCount} links to transaction log");
+
+    // From now on, all changes will be logged automatically
+    var newLink = loggingDecorator.Create();
+}
+```
+
+## Benefits
+
+1. **Full Database Recovery**: The transaction log can be used to fully restore a database, including its initial state
+2. **ACID Compliance**: Supports the ACID milestone by enabling complete transaction logging
+3. **Flexible Deployment**: Allows enabling transaction logging on existing databases without losing data
+4. **Simple API**: Single method call to push the snapshot
+
+## Implementation Plan
+
+1. Add `PushSnapshot()` method to `LoggingDecorator` class in `linksplatform/Data.Doublets`
+2. Add unit tests to verify snapshot functionality
+3. Update documentation with usage examples
+4. Release new version of `Platform.Data.Doublets` package
+5. Update `konard/LinksPlatform` repository to use new package version
+
+## Related Files
+
+- `linksplatform/Data.Doublets/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs`
+- Current version in use: `Platform.Data.Doublets 0.6.10`
+- LoggingDecorator was added in: commit `8a3544d` (2023-01-07)
+
+## References
+
+- Issue: https://github.com/konard/LinksPlatform/issues/46
+- Milestone: ACID
+- Related Package: Platform.Data.Doublets
+- Repository: https://github.com/linksplatform/Data.Doublets


### PR DESCRIPTION
## 🎯 Summary

This PR implements a solution for [issue #46](https://github.com/konard/LinksPlatform/issues/46): "Allow to push Links Data Snapshot to Transaction Log".

## 📝 Problem Statement

Currently, when transaction logging is enabled on an existing database using `LoggingDecorator` (from Platform.Data.Doublets 0.7+), only **future changes** are logged. The initial state of the database (all links that existed before logging was enabled) is not captured in the transaction log.

This creates a significant limitation: the transaction log cannot be used to fully restore a database because it's missing the initial state.

## ✨ Solution

This PR introduces two new classes that enable pushing a snapshot of existing database links to a transaction log:

### 1. `LinksSnapshotLogger<TLink>`
A utility class that writes all existing links in a database to a transaction log stream, formatting them as Create operations compatible with `LoggingDecorator`.

**Key features:**
- Iterates through all existing links in the database
- Writes each link as a Create operation to the log
- Uses the same format as `LoggingDecorator` for consistency
- Returns the count of links written

### 2. `LinksSnapshotLoggerCLI`
A command-line interface that makes it easy to use the snapshot logging feature.

**Usage:**
```bash
LinksSnapshotLogger <database-path> <log-file-path>
```

## 📋 Files Changed

- **Platform/Platform.Examples/LinksSnapshotLogger.cs** - Core utility class
- **Platform/Platform.Examples/LinksSnapshotLoggerCLI.cs** - Command-line interface
- **doc/snapshot-feature-proposal.md** - Detailed proposal and documentation

## 🔧 Implementation Details

The solution works with the current codebase (Platform.Data.Doublets 0.6.10) by directly accessing the `ILinks<TLink>` interface to iterate through all links and write them to a log file.

Example output format:
```
# Snapshot Start - 2025-10-16T17:30:00.0000000Z
# Total links in database: 3
Create. Before: 0: 0->0. After: 1: 1->1
Create. Before: 0: 0->0. After: 2: 2->2
Create. Before: 0: 0->0. After: 3: 1->2
# Snapshot End - 3 links written
```

## 💡 Benefits

1. **Full Database Recovery** - Transaction logs can now be used to completely restore a database
2. **ACID Compliance** - Supports the ACID milestone by enabling complete transaction logging
3. **Flexible Deployment** - Enables transaction logging on existing databases without data loss
4. **Backward Compatible** - Works with the current version of Platform.Data.Doublets
5. **Simple API** - Easy to use both programmatically and from command line

## 🚀 Usage Example

```csharp
using var links = new UnitedMemoryLinks<ulong>("db.links");
var snapshotLogger = new LinksSnapshotLogger<ulong>(links);

// Push snapshot to transaction log
var count = snapshotLogger.PushSnapshotToFile("transaction.log");
Console.WriteLine($"Wrote {count} links to transaction log");
```

## 🔮 Future Work

For a complete solution, a `PushSnapshot()` method should be added directly to the `LoggingDecorator` class in the `linksplatform/Data.Doublets` repository. See `doc/snapshot-feature-proposal.md` for detailed proposal.

## ✅ Testing

- ✅ Builds successfully with no errors or warnings
- ✅ Compatible with Platform.Data.Doublets 0.6.10
- ✅ Follows existing code style and conventions
- ✅ Includes bilingual documentation (English/Russian)

## 📚 Related

- Issue: #46
- Milestone: ACID
- Related Repository: [linksplatform/Data.Doublets](https://github.com/linksplatform/Data.Doublets)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


Fixes #46