### PR TITLE
Add Wikipedia references to technical terms in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-69-3b3a21b7
-Your prepared working directory: /tmp/gh-issue-solver-1760628415822
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-69-3b3a21b7
+Your prepared working directory: /tmp/gh-issue-solver-1760628415822
+
+Proceed.

--- a/index.md
+++ b/index.md
@@ -1,9 +1,9 @@
 # Links Platform ([русская версия](index.ru.md))
-Holistic system for storage and transformation of information (in development) based on associative model of data.
+Holistic system for storage and transformation of information (in development) based on [associative model of data](https://en.wikipedia.org/wiki/Associative_model_of_data).
 
 ## Prerequisites
-* Linux, macOS or Windows operating system.
-* [.NET Core](https://www.microsoft.com/net) SDK with version 2.2 or later.
+* [Linux](https://en.wikipedia.org/wiki/Linux), [macOS](https://en.wikipedia.org/wiki/MacOS) or [Windows](https://en.wikipedia.org/wiki/Microsoft_Windows) [operating system](https://en.wikipedia.org/wiki/Operating_system).
+* [.NET Core](https://www.microsoft.com/net) [SDK](https://en.wikipedia.org/wiki/Software_development_kit) with version 2.2 or later.
 * [MonoDevelop](https://www.monodevelop.com/), [Visual Studio](https://visualstudio.microsoft.com) or any other [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment) or just a [text editor](https://en.wikipedia.org/wiki/Text_editor).
 
 ## Links Platform's NuGet packages
@@ -25,31 +25,31 @@ A native Triplets implementation.
 ### Auxiliary packages
 
 #### [Platform.Data.Memory](https://linksplatform.github.io/Memory)
-Platform.Data.Memory class library contains classes for memory management simplification. There you can find multiple implementations of [IMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.IMemory.html) interface.
+Platform.Data.Memory [class library](https://en.wikipedia.org/wiki/Library_(computing)) contains classes for [memory management](https://en.wikipedia.org/wiki/Memory_management) simplification. There you can find multiple implementations of [IMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.IMemory.html) [interface](https://en.wikipedia.org/wiki/Interface_(computing)).
 
-The data can be accessed using [the raw pointer](https://linksplatform.github.io/Memory/api/Platform.Memory.IDirectMemory.html) or [by element's index](https://linksplatform.github.io/Memory/api/Platform.Memory.IArrayMemory-1.html) and can be stored in volatile memory:
+The data can be accessed using [the raw pointer](https://linksplatform.github.io/Memory/api/Platform.Memory.IDirectMemory.html) or [by element's index](https://linksplatform.github.io/Memory/api/Platform.Memory.IArrayMemory-1.html) and can be stored in [volatile memory](https://en.wikipedia.org/wiki/Volatile_memory):
 * [HeapResizableDirect](https://linksplatform.github.io/Memory/api/Platform.Memory.HeapResizableDirectMemory.html),
 * [ArrayMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.ArrayMemory-1.html)
 
-or in non-volatile memory:
+or in [non-volatile memory](https://en.wikipedia.org/wiki/Non-volatile_memory):
 * [FileMappedResizableDirectMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.FileMappedResizableDirectMemory.html),
 * [TemporaryFileMappedResizableDirectMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.TemporaryFileMappedResizableDirectMemory.html),
 * [FileArrayMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.FileArrayMemory-1.html).
 
 #### [Platform.Data.Communication](https://linksplatform.github.io/Communication)
-Platform.Data.Communication class library contains classes for communication simplification supporting different protocols.
+Platform.Data.Communication class library contains classes for [communication](https://en.wikipedia.org/wiki/Communication_protocol) simplification supporting different [protocols](https://en.wikipedia.org/wiki/Communication_protocol).
 
 ##### Gexf
-XML-mapping classes for [Graph Exchange XML Format](https://gephi.org/gexf/format/).
+[XML](https://en.wikipedia.org/wiki/XML)-mapping classes for [Graph Exchange XML Format](https://gephi.org/gexf/format/).
 
 ##### Udp
-`UdpSender` and `UdpReceiver` classes to simplify implementation of different roles of `UdpClient`.
+`UdpSender` and `UdpReceiver` classes to simplify implementation of different roles of `UdpClient` using [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol).
 
 ##### Xml
-A `Serializer` class to help with XML serialization and deserialization.
+A `Serializer` class to help with [XML serialization](https://en.wikipedia.org/wiki/XML) and [deserialization](https://en.wikipedia.org/wiki/Serialization).
 
 #### [Platform.Collections.Methods](https://linksplatform.github.io/Collections.Methods)
-Platform.Collections.Methods class library contains classes with storage/state agnostic implementation of lists and trees.
+Platform.Collections.Methods class library contains classes with storage/state agnostic implementation of [lists](https://en.wikipedia.org/wiki/List_(abstract_data_type)) and [trees](https://en.wikipedia.org/wiki/Tree_(data_structure)).
 
 #### [Platform.IO](https://linksplatform.github.io/IO)
 Platform.Collections.Methods class library contains classes ... .
@@ -100,13 +100,13 @@ Platform.Collections.Methods class library contains classes ... .
 Platform.Collections.Methods class library contains `Range` struct with Minimum and Maximum fields.
 
 #### [Platform.Disposables](https://linksplatform.github.io/Disposables)
-Platform.Collections.Methods class library contains classes and interfaces that help to make objects disposable in a fast, short, easy and safe way.
+Platform.Collections.Methods class library contains classes and [interfaces](https://en.wikipedia.org/wiki/Interface_(computing)) that help to make [objects](https://en.wikipedia.org/wiki/Object_(computer_science)) [disposable](https://en.wikipedia.org/wiki/Dispose_pattern) in a fast, short, easy and safe way.
 
 ##### DisposableBase
-`Platform.Disposables.DisposableBase` abstract class tries to dispose the object at both on instance destruction and `OnProcessExit` whatever comes first even if `Dispose` method was not called anywhere by user.
+`Platform.Disposables.DisposableBase` [abstract class](https://en.wikipedia.org/wiki/Abstract_type) tries to dispose the object at both on instance destruction and `OnProcessExit` whatever comes first even if `Dispose` method was not called anywhere by user.
 
 ##### Yet another IDisposable
-The `Platform.Disposables.IDisposable` interface extends the `System.IDisposable` with `IsDisposed` property and `Destruct` method.
+The `Platform.Disposables.IDisposable` interface extends the `System.IDisposable` with `IsDisposed` [property](https://en.wikipedia.org/wiki/Property_(programming)) and `Destruct` [method](https://en.wikipedia.org/wiki/Method_(computer_programming)).
 
 #### [Platform.Exceptions](https://linksplatform.github.io/Exceptions)
 Platform.Collections.Methods class library contains classes ... .

--- a/index.ru.md
+++ b/index.ru.md
@@ -1,9 +1,9 @@
 # Платформа Связей ([english version](index.md))
-Целостная система для хранения и обработки информации (в разработке), основанная на ассоциативной модели данных.
+Целостная система для хранения и обработки информации (в разработке), основанная на [ассоциативной модели данных](https://ru.wikipedia.org/wiki/%D0%90%D1%81%D1%81%D0%BE%D1%86%D0%B8%D0%B0%D1%82%D0%B8%D0%B2%D0%BD%D0%B0%D1%8F_%D0%BC%D0%BE%D0%B4%D0%B5%D0%BB%D1%8C_%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85).
 
 ## Требования
-* Операционная система Linux, macOS или Windows.
-* [.NET Core](https://www.microsoft.com/net) SDK версии 2.2 или выше.
+* [Операционная система](https://ru.wikipedia.org/wiki/%D0%9E%D0%BF%D0%B5%D1%80%D0%B0%D1%86%D0%B8%D0%BE%D0%BD%D0%BD%D0%B0%D1%8F_%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D0%B0) [Linux](https://ru.wikipedia.org/wiki/Linux), [macOS](https://ru.wikipedia.org/wiki/MacOS) или [Windows](https://ru.wikipedia.org/wiki/Windows).
+* [.NET Core](https://www.microsoft.com/net) [SDK](https://ru.wikipedia.org/wiki/SDK) версии 2.2 или выше.
 * [MonoDevelop](https://www.monodevelop.com/), [Visual Studio](https://visualstudio.microsoft.com) или любая другая [ИСР](https://ru.wikipedia.org/wiki/%D0%98%D0%BD%D1%82%D0%B5%D0%B3%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%B0%D1%8F_%D1%81%D1%80%D0%B5%D0%B4%D0%B0_%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B8) или просто [текстовый редактор](https://ru.wikipedia.org/wiki/%D0%A2%D0%B5%D0%BA%D1%81%D1%82%D0%BE%D0%B2%D1%8B%D0%B9_%D1%80%D0%B5%D0%B4%D0%B0%D0%BA%D1%82%D0%BE%D1%80).
 
 ## NuGet пакеты Платформы Связей
@@ -11,7 +11,7 @@
 ### Основные пакеты
 
 #### [Platform.Data](https://linksplatform.github.io/Data)
-Общие интерфейсы и классы для [Дуплетов](https://linksplatform.github.io/Data.Doublets/README.ru.html) и [Триплетов](https://linksplatform.github.io/Data.Triplets).
+Общие [интерфейсы](https://ru.wikipedia.org/wiki/%D0%98%D0%BD%D1%82%D0%B5%D1%80%D1%84%D0%B5%D0%B9%D1%81_(%D0%BE%D0%B1%D1%8A%D0%B5%D0%BA%D1%82%D0%BD%D0%BE-%D0%BE%D1%80%D0%B8%D0%B5%D0%BD%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%BE%D0%B5_%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)) и [классы](https://ru.wikipedia.org/wiki/%D0%9A%D0%BB%D0%B0%D1%81%D1%81_(%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)) для [Дуплетов](https://linksplatform.github.io/Data.Doublets/README.ru.html) и [Триплетов](https://linksplatform.github.io/Data.Triplets).
 
 #### [Platform.Data.Doublets](https://linksplatform.github.io/Data.Doublets/README.ru.html)
 #### [Platform.Data.Triplets](https://linksplatform.github.io/Data.Triplets)
@@ -21,13 +21,13 @@
 
 #### [Platform.Data.Memory](https://linksplatform.github.io/Memory)
 
-Библиотека классов Platform.Data.Memory содержит классы для упрощения управления памятью. Там вы можете найти множество реализаций интерфейса [IMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.IMemory.html).
+[Библиотека классов](https://ru.wikipedia.org/wiki/%D0%91%D0%B8%D0%B1%D0%BB%D0%B8%D0%BE%D1%82%D0%B5%D0%BA%D0%B0_(%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)) Platform.Data.Memory содержит классы для упрощения [управления памятью](https://ru.wikipedia.org/wiki/%D0%A3%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_%D0%BF%D0%B0%D0%BC%D1%8F%D1%82%D1%8C%D1%8E). Там вы можете найти множество реализаций интерфейса [IMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.IMemory.html).
 
-Доступ к данным может осуществляться через [указатель](https://linksplatform.github.io/Memory/api/Platform.Memory.IDirectMemory.html) или через [индексатор](https://linksplatform.github.io/Memory/api/Platform.Memory.IArrayMemory-1.html) и данные могут храниться в энергозависимой памяти:
+Доступ к данным может осуществляться через [указатель](https://linksplatform.github.io/Memory/api/Platform.Memory.IDirectMemory.html) или через [индексатор](https://linksplatform.github.io/Memory/api/Platform.Memory.IArrayMemory-1.html) и данные могут храниться в [энергозависимой памяти](https://ru.wikipedia.org/wiki/%D0%AD%D0%BD%D0%B5%D1%80%D0%B3%D0%BE%D0%B7%D0%B0%D0%B2%D0%B8%D1%81%D0%B8%D0%BC%D0%B0%D1%8F_%D0%BF%D0%B0%D0%BC%D1%8F%D1%82%D1%8C):
 * [HeapResizableDirect](https://linksplatform.github.io/Memory/api/Platform.Memory.HeapResizableDirectMemory.html),
 * [ArrayMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.ArrayMemory-1.html)
 
-или в энергонезависимой памяти:
+или в [энергонезависимой памяти](https://ru.wikipedia.org/wiki/%D0%AD%D0%BD%D0%B5%D1%80%D0%B3%D0%BE%D0%BD%D0%B5%D0%B7%D0%B0%D0%B2%D0%B8%D1%81%D0%B8%D0%BC%D0%B0%D1%8F_%D0%BF%D0%B0%D0%BC%D1%8F%D1%82%D1%8C):
 * [FileMappedResizableDirectMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.FileMappedResizableDirectMemory.html),
 * [TemporaryFileMappedResizableDirectMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.TemporaryFileMappedResizableDirectMemory.html),
 * [FileArrayMemory](https://linksplatform.github.io/Memory/api/Platform.Memory.FileArrayMemory-1.html).


### PR DESCRIPTION
## Summary

Added Wikipedia references to technical terms in documentation files to improve accessibility and understanding for readers.

### Changes Made

#### Modified Files
- **index.md** (English documentation)
  - Added Wikipedia links for: associative model of data, Linux, macOS, Windows, operating system, SDK, class library, memory management, interface, volatile memory, non-volatile memory, communication protocols, XML, UDP, serialization, lists, trees, objects, dispose pattern, abstract class, property, method
  
- **index.ru.md** (Russian documentation)
  - Added Wikipedia links for: ассоциативная модель данных, операционная система, Linux, macOS, Windows, SDK, интерфейсы, классы, библиотека классов, управление памятью, энергозависимая память, энергонезависимая память

### Technical Details

All Wikipedia links were added to technical terms that would benefit readers by providing additional context and definitions. Both English (en.wikipedia.org) and Russian (ru.wikipedia.org) Wikipedia articles were linked appropriately for each language version.

The changes maintain consistency with existing documentation style and follow the patterns observed in README.ru.md which already had Wikipedia references.

### Testing

All added Wikipedia links point to valid Wikipedia articles that are relevant to the technical terms they describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #69