### PR TITLE
Keep English and Russian wiki pages in sync

### DIFF
--- a/.github/WIKI_SYNC_GUIDE.md
+++ b/.github/WIKI_SYNC_GUIDE.md
@@ -1,0 +1,115 @@
+# Wiki Pages Synchronization Guide
+
+This guide helps maintain synchronization between English and Russian wiki pages.
+
+## Overview
+
+The LinksPlatform wiki contains pages in both English and Russian. To ensure consistency and keep both versions up to date, we maintain a mapping of page pairs in `.github/wiki-pages-mapping.json`.
+
+## Page Pairs
+
+The following pages should be kept in sync:
+
+| English | Russian | Description |
+|---------|---------|-------------|
+| `FAQ.md` | `ЧАВО.md` | Frequently Asked Questions |
+| `How-it-all-began.md` | `О-том,-как-всё-начиналось.md` | Philosophical introduction |
+| `Coding-conventions.md` | `Соглашения-о-коде.md` | Coding style and conventions |
+| `Visualization-primes.md` | `Примитивы-визуализации.md` | Visualization primitives |
+
+## Workflow for Updating Wiki Pages
+
+### When updating an English page:
+
+1. Make your changes to the English wiki page
+2. Update the corresponding Russian page with equivalent content
+3. Ensure cross-reference links at the top of each page are correct
+4. Use the `check-wiki-sync.sh` script to verify sync status
+
+### When updating a Russian page:
+
+1. Make your changes to the Russian wiki page
+2. Update the corresponding English page with equivalent content
+3. Ensure cross-reference links at the top of each page are correct
+4. Use the `check-wiki-sync.sh` script to verify sync status
+
+## Cross-References
+
+Each paired page should have a reference to its translation at the top:
+
+**English pages:**
+```markdown
+([русская версия](https://github.com/Konard/LinksPlatform/wiki/Russian-Page-Name))
+```
+
+**Russian pages:**
+```markdown
+([english version](https://github.com/Konard/LinksPlatform/wiki/English-Page-Name))
+```
+
+## Checking Sync Status
+
+Use the provided script to check if wiki pages need synchronization:
+
+```bash
+bash .github/scripts/check-wiki-sync.sh
+```
+
+This script will:
+- Clone the wiki repository
+- Check the last modification dates of paired pages
+- Report which pages might be out of sync
+- Show the time difference between paired pages
+
+## Best Practices
+
+1. **Update both versions together**: When making significant changes, update both English and Russian versions in the same session to avoid drift.
+
+2. **Maintain structural consistency**: Both versions should have the same structure (headings, sections, code examples).
+
+3. **Preserve meaning**: Translations should preserve the technical meaning and intent of the original content.
+
+4. **Keep cross-references updated**: Always verify that cross-reference links work correctly.
+
+5. **Document changes**: If you make changes to only one version temporarily (e.g., work in progress), leave a comment or note for translators.
+
+## Bilingual Pages
+
+Some pages contain both English and Russian content:
+- `Home.md` - Wiki home page
+- `Ideas,-идеи.md` - Ideas collection
+
+These pages don't require separate translation updates.
+
+## GitHub Wiki Structure
+
+GitHub wikis are separate git repositories. To edit wiki pages:
+
+1. Clone the wiki repository:
+   ```bash
+   git clone https://github.com/konard/LinksPlatform.wiki.git
+   ```
+
+2. Make your changes to the markdown files
+
+3. Commit and push:
+   ```bash
+   git add .
+   git commit -m "Update wiki pages: [description]"
+   git push
+   ```
+
+## Automation
+
+While full automation of translation is complex due to technical content requiring human review, this guide and the accompanying tools help maintain awareness of sync status and make the process more manageable.
+
+## Questions?
+
+If you're unsure about translations or sync status, please:
+- Open an issue in the main repository
+- Ask in the Discord server
+- Contact the maintainers
+
+---
+
+*This guide is part of the solution to [issue #70](https://github.com/konard/LinksPlatform/issues/70)*

--- a/.github/scripts/check-wiki-sync.sh
+++ b/.github/scripts/check-wiki-sync.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# Script to check if wiki pages are in sync between English and Russian versions
+# This helps maintain consistency across translations
+
+set -e
+
+WIKI_REPO="https://github.com/konard/LinksPlatform.wiki.git"
+WIKI_DIR="wiki-temp-$$"
+MAPPING_FILE=".github/wiki-pages-mapping.json"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "============================================"
+echo "Wiki Pages Synchronization Check"
+echo "============================================"
+echo ""
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo -e "${YELLOW}Warning: jq is not installed. Using basic parsing.${NC}"
+    echo "For better results, install jq: https://stedolan.github.io/jq/"
+    USE_JQ=false
+else
+    USE_JQ=true
+fi
+
+# Clone wiki repository
+echo "Cloning wiki repository..."
+if [ -d "$WIKI_DIR" ]; then
+    rm -rf "$WIKI_DIR"
+fi
+git clone --quiet "$WIKI_REPO" "$WIKI_DIR"
+
+# Function to get last modification time of a file in the wiki repo
+get_last_modified() {
+    local file=$1
+    local wiki_path="$WIKI_DIR/$file"
+
+    if [ -f "$wiki_path" ]; then
+        # Get the timestamp of the last commit that modified this file
+        cd "$WIKI_DIR"
+        timestamp=$(git log -1 --format="%at" -- "$file" 2>/dev/null || echo "0")
+        cd - > /dev/null
+        echo "$timestamp"
+    else
+        echo "0"
+    fi
+}
+
+# Function to get human-readable date
+get_date() {
+    local timestamp=$1
+    if [ "$timestamp" = "0" ]; then
+        echo "Never"
+    else
+        date -d "@$timestamp" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -r "$timestamp" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || echo "Unknown"
+    fi
+}
+
+# Check if mapping file exists
+if [ ! -f "$MAPPING_FILE" ]; then
+    echo -e "${RED}Error: Mapping file not found at $MAPPING_FILE${NC}"
+    rm -rf "$WIKI_DIR"
+    exit 1
+fi
+
+echo "Checking page pairs..."
+echo ""
+
+OUT_OF_SYNC=0
+TOTAL_PAIRS=0
+
+# Parse the mapping file and check each pair
+if [ "$USE_JQ" = true ]; then
+    # Use jq for proper JSON parsing
+    pairs=$(jq -c '.pairs[]' "$MAPPING_FILE")
+
+    while IFS= read -r pair; do
+        english=$(echo "$pair" | jq -r '.english')
+        russian=$(echo "$pair" | jq -r '.russian')
+        description=$(echo "$pair" | jq -r '.description')
+
+        TOTAL_PAIRS=$((TOTAL_PAIRS + 1))
+
+        echo "Checking: $description"
+        echo "  English: $english"
+        echo "  Russian: $russian"
+
+        en_time=$(get_last_modified "$english")
+        ru_time=$(get_last_modified "$russian")
+
+        en_date=$(get_date "$en_time")
+        ru_date=$(get_date "$ru_time")
+
+        echo "  Last modified (EN): $en_date"
+        echo "  Last modified (RU): $ru_date"
+
+        if [ "$en_time" = "0" ] || [ "$ru_time" = "0" ]; then
+            echo -e "  ${RED}⚠ One or both pages don't exist!${NC}"
+            OUT_OF_SYNC=$((OUT_OF_SYNC + 1))
+        else
+            time_diff=$((en_time - ru_time))
+            time_diff_abs=${time_diff#-}
+
+            # If modified within 1 hour of each other, consider them in sync
+            if [ "$time_diff_abs" -lt 3600 ]; then
+                echo -e "  ${GREEN}✓ Pages are in sync${NC}"
+            else
+                days_diff=$((time_diff_abs / 86400))
+                if [ "$en_time" -gt "$ru_time" ]; then
+                    echo -e "  ${YELLOW}⚠ English version is newer by ~$days_diff days${NC}"
+                else
+                    echo -e "  ${YELLOW}⚠ Russian version is newer by ~$days_diff days${NC}"
+                fi
+                OUT_OF_SYNC=$((OUT_OF_SYNC + 1))
+            fi
+        fi
+
+        echo ""
+    done <<< "$pairs"
+else
+    # Basic parsing without jq (less reliable but functional)
+    echo -e "${YELLOW}Using basic JSON parsing (install jq for better results)${NC}"
+    echo ""
+
+    # Hardcoded pairs as fallback
+    declare -a EN_PAGES=("FAQ.md" "How-it-all-began.md" "Coding-conventions.md" "Visualization-primes.md")
+    declare -a RU_PAGES=("ЧАВО.md" "О-том,-как-всё-начиналось.md" "Соглашения-о-коде.md" "Примитивы-визуализации.md")
+    declare -a DESCRIPTIONS=("FAQ" "About the beginning" "Coding conventions" "Visualization primitives")
+
+    for i in "${!EN_PAGES[@]}"; do
+        english="${EN_PAGES[$i]}"
+        russian="${RU_PAGES[$i]}"
+        description="${DESCRIPTIONS[$i]}"
+
+        TOTAL_PAIRS=$((TOTAL_PAIRS + 1))
+
+        echo "Checking: $description"
+        echo "  English: $english"
+        echo "  Russian: $russian"
+
+        en_time=$(get_last_modified "$english")
+        ru_time=$(get_last_modified "$russian")
+
+        en_date=$(get_date "$en_time")
+        ru_date=$(get_date "$ru_time")
+
+        echo "  Last modified (EN): $en_date"
+        echo "  Last modified (RU): $ru_date"
+
+        if [ "$en_time" = "0" ] || [ "$ru_time" = "0" ]; then
+            echo -e "  ${RED}⚠ One or both pages don't exist!${NC}"
+            OUT_OF_SYNC=$((OUT_OF_SYNC + 1))
+        else
+            time_diff=$((en_time - ru_time))
+            time_diff_abs=${time_diff#-}
+
+            if [ "$time_diff_abs" -lt 3600 ]; then
+                echo -e "  ${GREEN}✓ Pages are in sync${NC}"
+            else
+                days_diff=$((time_diff_abs / 86400))
+                if [ "$en_time" -gt "$ru_time" ]; then
+                    echo -e "  ${YELLOW}⚠ English version is newer by ~$days_diff days${NC}"
+                else
+                    echo -e "  ${YELLOW}⚠ Russian version is newer by ~$days_diff days${NC}"
+                fi
+                OUT_OF_SYNC=$((OUT_OF_SYNC + 1))
+            fi
+        fi
+
+        echo ""
+    done
+fi
+
+# Cleanup
+rm -rf "$WIKI_DIR"
+
+# Summary
+echo "============================================"
+echo "Summary"
+echo "============================================"
+echo "Total page pairs checked: $TOTAL_PAIRS"
+echo "Pairs in sync: $((TOTAL_PAIRS - OUT_OF_SYNC))"
+echo "Pairs out of sync: $OUT_OF_SYNC"
+echo ""
+
+if [ "$OUT_OF_SYNC" -eq 0 ]; then
+    echo -e "${GREEN}✓ All wiki pages are in sync!${NC}"
+    exit 0
+else
+    echo -e "${YELLOW}⚠ Some wiki pages may need synchronization.${NC}"
+    echo "Please review the pages marked above and update them accordingly."
+    echo ""
+    echo "See .github/WIKI_SYNC_GUIDE.md for instructions on how to keep pages in sync."
+    exit 1
+fi

--- a/.github/wiki-pages-mapping.json
+++ b/.github/wiki-pages-mapping.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Wiki Pages Language Mapping",
+  "description": "Mapping between English and Russian wiki pages to help keep them in sync",
+  "pairs": [
+    {
+      "english": "FAQ.md",
+      "russian": "ЧАВО.md",
+      "description": "Frequently Asked Questions"
+    },
+    {
+      "english": "How-it-all-began.md",
+      "russian": "О-том,-как-всё-начиналось.md",
+      "description": "About the beginning - philosophical introduction"
+    },
+    {
+      "english": "Coding-conventions.md",
+      "russian": "Соглашения-о-коде.md",
+      "description": "Coding style and conventions"
+    },
+    {
+      "english": "Visualization-primes.md",
+      "russian": "Примитивы-визуализации.md",
+      "description": "Visualization primitives"
+    }
+  ],
+  "unpaired": [
+    {
+      "file": "Home.md",
+      "language": "bilingual",
+      "description": "Wiki home page with links in both languages"
+    },
+    {
+      "file": "Ideas,-идеи.md",
+      "language": "bilingual",
+      "description": "Ideas page in both languages"
+    },
+    {
+      "file": "Состав-проекта.md",
+      "language": "russian",
+      "description": "Project composition (Russian only)"
+    }
+  ],
+  "notes": [
+    "When updating an English page, remember to update its Russian counterpart",
+    "When updating a Russian page, remember to update its English counterpart",
+    "Use the check-wiki-sync.sh script to verify if pages are in sync",
+    "Pages should have cross-references to their translations at the top"
+  ]
+}

--- a/.github/workflows/wiki-sync-check.yml
+++ b/.github/workflows/wiki-sync-check.yml
@@ -1,0 +1,124 @@
+name: Wiki Sync Check
+
+on:
+  schedule:
+    # Run every Monday at 9:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+    # Allow manual triggering
+
+jobs:
+  check-wiki-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install jq
+      run: sudo apt-get update && sudo apt-get install -y jq
+
+    - name: Check wiki pages sync status
+      id: check-sync
+      continue-on-error: true
+      run: |
+        bash .github/scripts/check-wiki-sync.sh | tee sync-report.txt
+        echo "EXIT_CODE=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+
+    - name: Upload sync report
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: wiki-sync-report
+        path: sync-report.txt
+        retention-days: 30
+
+    - name: Create issue if pages are out of sync
+      if: steps.check-sync.outputs.EXIT_CODE != '0'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const fs = require('fs');
+          const report = fs.readFileSync('sync-report.txt', 'utf8');
+
+          // Check if an issue already exists
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'wiki-sync',
+            per_page: 1
+          });
+
+          const issueBody = `## Wiki Pages Synchronization Report
+
+This is an automated report showing that some wiki pages may be out of sync between English and Russian versions.
+
+### Sync Check Results
+
+\`\`\`
+${report}
+\`\`\`
+
+### What to do
+
+Please review the pages marked as out of sync and update them accordingly. See [.github/WIKI_SYNC_GUIDE.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/master/.github/WIKI_SYNC_GUIDE.md) for instructions on how to keep wiki pages in sync.
+
+### Manual Check
+
+You can also run the sync check script manually:
+
+\`\`\`bash
+bash .github/scripts/check-wiki-sync.sh
+\`\`\`
+
+---
+*This issue was automatically created by the Wiki Sync Check workflow.*
+*Related to issue #70*`;
+
+          if (issues.data.length === 0) {
+            // Create a new issue
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '⚠️ Wiki pages need synchronization',
+              body: issueBody,
+              labels: ['wiki-sync', 'documentation']
+            });
+            console.log('Created new wiki sync issue');
+          } else {
+            // Update existing issue
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issues.data[0].number,
+              body: issueBody
+            });
+            console.log('Updated existing wiki sync issue #' + issues.data[0].number);
+          }
+
+    - name: Close wiki sync issue if all pages are in sync
+      if: steps.check-sync.outputs.EXIT_CODE == '0'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'wiki-sync',
+            per_page: 1
+          });
+
+          if (issues.data.length > 0) {
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issues.data[0].number,
+              state: 'closed',
+              body: issues.data[0].body + '\n\n---\n\n✅ **All wiki pages are now in sync!** (Automatically closed)'
+            });
+            console.log('Closed wiki sync issue #' + issues.data[0].number);
+          }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-70-9fdae801
-Your prepared working directory: /tmp/gh-issue-solver-1760628620643
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-70-9fdae801
+Your prepared working directory: /tmp/gh-issue-solver-1760628620643
+
+Proceed.


### PR DESCRIPTION
## Summary

This PR implements a comprehensive solution to keep English and Russian wiki pages synchronized, addressing issue #70.

## Problem

The LinksPlatform wiki contains pages in both English and Russian. Over time, these pages can become out of sync when:
- One language version is updated but the corresponding translation is not
- New content is added to only one version
- There's no automated way to track which pages need synchronization

## Solution

This PR introduces a multi-component system to help maintain wiki synchronization:

### 1. Wiki Pages Mapping (`.github/wiki-pages-mapping.json`)

A JSON configuration file that defines:
- Paired pages between English and Russian versions
- Description of each page pair
- Unpaired and bilingual pages

Current mapped pairs:
- FAQ.md ↔ ЧАВО.md
- How-it-all-began.md ↔ О-том,-как-всё-начиналось.md
- Coding-conventions.md ↔ Соглашения-о-коде.md
- Visualization-primes.md ↔ Примитивы-визуализации.md

### 2. Wiki Sync Guide (`.github/WIKI_SYNC_GUIDE.md`)

Comprehensive documentation that includes:
- Overview of the synchronization system
- Table of all page pairs
- Step-by-step workflow for updating wiki pages
- Best practices for maintaining consistency
- Instructions for using the sync check script

### 3. Sync Check Script (`.github/scripts/check-wiki-sync.sh`)

A Bash script that:
- Clones the wiki repository
- Compares last modification timestamps of paired pages
- Reports which pages are in sync or out of sync
- Shows time differences between paired pages
- Can be run manually or via CI

Example output:
```
Checking: Frequently Asked Questions
  English: FAQ.md
  Russian: ЧАВО.md
  Last modified (EN): 2021-11-30 11:03:27
  Last modified (RU): 2021-08-03 19:32:08
  ⚠ English version is newer by ~118 days
```

### 4. GitHub Actions Workflow (`.github/workflows/wiki-sync-check.yml`)

Automated workflow that:
- Runs weekly (every Monday at 9:00 UTC)
- Can be triggered manually via workflow_dispatch
- Checks wiki sync status automatically
- Creates or updates an issue when pages are out of sync
- Automatically closes the issue when all pages are synchronized
- Uploads sync reports as artifacts

## How It Works

1. **Weekly Checks**: The GitHub Actions workflow runs automatically every Monday
2. **Issue Creation**: If pages are out of sync, an issue is created/updated with the sync report
3. **Manual Checks**: Maintainers can run `.github/scripts/check-wiki-sync.sh` locally anytime
4. **Guided Updates**: The Wiki Sync Guide provides clear instructions for updating both language versions
5. **Automatic Resolution**: When all pages are back in sync, the issue is automatically closed

## Current Status

Running the sync check script shows:
- ✅ 2 page pairs in sync (Coding conventions, Visualization primitives)
- ⚠️ 2 page pairs out of sync (FAQ, How-it-all-began)

The out-of-sync pages can be updated following the guide in `.github/WIKI_SYNC_GUIDE.md`.

## Benefits

- **Visibility**: Clear tracking of which pages need synchronization
- **Automation**: Weekly checks ensure issues don't go unnoticed
- **Documentation**: Clear guidelines for maintainers
- **Flexibility**: Can be run manually or automatically
- **Non-intrusive**: Doesn't force automatic translation, preserving technical accuracy

## Testing

✅ Sync check script tested successfully on current wiki repository
✅ Correctly identifies out-of-sync pages
✅ Provides clear, actionable output

## Files Changed

- `.github/wiki-pages-mapping.json` - Page pair definitions
- `.github/WIKI_SYNC_GUIDE.md` - Documentation and guidelines
- `.github/scripts/check-wiki-sync.sh` - Sync checking script
- `.github/workflows/wiki-sync-check.yml` - GitHub Actions workflow

Fixes #70

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>