### PR TITLE
Add IObservable/IObserver example for links events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-92-d2667d01
-Your prepared working directory: /tmp/gh-issue-solver-1760634629271
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-92-d2667d01
+Your prepared working directory: /tmp/gh-issue-solver-1760634629271
+
+Proceed.

--- a/Platform/Platform.Examples/LinkChange.cs
+++ b/Platform/Platform.Examples/LinkChange.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// <para>
+    /// Represents a change event for a link.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    /// <typeparam name="TLinkAddress">The type of the link address.</typeparam>
+    public class LinkChange<TLinkAddress>
+    {
+        /// <summary>
+        /// <para>
+        /// Gets the state of the link before the change (null for create operations).
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        public IList<TLinkAddress> Before { get; }
+
+        /// <summary>
+        /// <para>
+        /// Gets the state of the link after the change (null for delete operations).
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        public IList<TLinkAddress> After { get; }
+
+        /// <summary>
+        /// <para>
+        /// Gets the type of change operation.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        public LinkChangeType ChangeType { get; }
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new instance of the <see cref="LinkChange{TLinkAddress}"/> class.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="before">The state of the link before the change.</param>
+        /// <param name="after">The state of the link after the change.</param>
+        /// <param name="changeType">The type of change operation.</param>
+        public LinkChange(IList<TLinkAddress> before, IList<TLinkAddress> after, LinkChangeType changeType)
+        {
+            Before = before;
+            After = after;
+            ChangeType = changeType;
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Defines the type of change operation on a link.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    public enum LinkChangeType
+    {
+        /// <summary>
+        /// <para>
+        /// A new link was created.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        Create,
+
+        /// <summary>
+        /// <para>
+        /// An existing link was updated.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        Update,
+
+        /// <summary>
+        /// <para>
+        /// A link was deleted.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        Delete
+    }
+}

--- a/Platform/Platform.Examples/LinksObserver.cs
+++ b/Platform/Platform.Examples/LinksObserver.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using Platform.Converters;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// <para>
+    /// Represents a simple observer that logs link change events to the console.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    /// <typeparam name="TLinkAddress">The type of the link address.</typeparam>
+    public class LinksObserver<TLinkAddress> : IObserver<LinkChange<TLinkAddress>>
+    {
+        private static readonly UncheckedConverter<TLinkAddress, long> _addressToInt64Converter = UncheckedConverter<TLinkAddress, long>.Default;
+        private readonly string _name;
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new instance of the <see cref="LinksObserver{TLinkAddress}"/> class.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="name">The name of the observer (used for identification in console output).</param>
+        public LinksObserver(string name)
+        {
+            _name = name ?? "Observer";
+        }
+
+        /// <inheritdoc/>
+        public void OnNext(LinkChange<TLinkAddress> change)
+        {
+            switch (change.ChangeType)
+            {
+                case LinkChangeType.Create:
+                    OnLinkCreated(change.After);
+                    break;
+                case LinkChangeType.Update:
+                    OnLinkUpdated(change.Before, change.After);
+                    break;
+                case LinkChangeType.Delete:
+                    OnLinkDeleted(change.Before);
+                    break;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error)
+        {
+            Console.WriteLine($"[{_name}] Error: {error.Message}");
+        }
+
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+            Console.WriteLine($"[{_name}] Observation completed.");
+        }
+
+        /// <summary>
+        /// <para>
+        /// Called when a new link is created.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="link">The created link.</param>
+        protected virtual void OnLinkCreated(IList<TLinkAddress> link)
+        {
+            if (link != null)
+            {
+                Console.WriteLine($"[{_name}] Link created: {FormatLink(link)}");
+            }
+        }
+
+        /// <summary>
+        /// <para>
+        /// Called when a link is updated.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="before">The link state before update.</param>
+        /// <param name="after">The link state after update.</param>
+        protected virtual void OnLinkUpdated(IList<TLinkAddress> before, IList<TLinkAddress> after)
+        {
+            if (before != null && after != null)
+            {
+                Console.WriteLine($"[{_name}] Link updated: {FormatLink(before)} -> {FormatLink(after)}");
+            }
+        }
+
+        /// <summary>
+        /// <para>
+        /// Called when a link is deleted.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="link">The deleted link.</param>
+        protected virtual void OnLinkDeleted(IList<TLinkAddress> link)
+        {
+            if (link != null)
+            {
+                Console.WriteLine($"[{_name}] Link deleted: {FormatLink(link)}");
+            }
+        }
+
+        private string FormatLink(IList<TLinkAddress> link)
+        {
+            if (link.Count >= 3)
+            {
+                return $"({_addressToInt64Converter.Convert(link[0])}: {_addressToInt64Converter.Convert(link[1])} -> {_addressToInt64Converter.Convert(link[2])})";
+            }
+            return string.Join(", ", link);
+        }
+    }
+}

--- a/Platform/Platform.Examples/ObservableLinks.cs
+++ b/Platform/Platform.Examples/ObservableLinks.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using Platform.Data;
+using Platform.Data.Doublets;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// <para>
+    /// Represents a wrapper for ILinks that implements the IObservable pattern for link change events.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    /// <typeparam name="TLinkAddress">The type of the link address.</typeparam>
+    public class ObservableLinks<TLinkAddress> : IObservable<LinkChange<TLinkAddress>>
+    {
+        private readonly ILinks<TLinkAddress> _links;
+        private readonly List<IObserver<LinkChange<TLinkAddress>>> _observers;
+        private readonly object _observersLock = new object();
+
+        /// <summary>
+        /// <para>
+        /// Gets the underlying ILinks implementation.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        public ILinks<TLinkAddress> Links => _links;
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new instance of the <see cref="ObservableLinks{TLinkAddress}"/> class.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="links">The underlying ILinks implementation to wrap.</param>
+        public ObservableLinks(ILinks<TLinkAddress> links)
+        {
+            _links = links ?? throw new ArgumentNullException(nameof(links));
+            _observers = new List<IObserver<LinkChange<TLinkAddress>>>();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Creates a link and notifies all observers.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="source">The source of the link.</param>
+        /// <param name="target">The target of the link.</param>
+        /// <returns>The address of the created link.</returns>
+        public TLinkAddress Create(TLinkAddress source, TLinkAddress target)
+        {
+            // Use GetOrCreate extension method to create the link
+            var result = _links.GetOrCreate(source, target);
+
+            // Create the "after" state - a link with [index, source, target]
+            var after = new TLinkAddress[] { result, source, target };
+
+            // Notify observers about the create operation
+            NotifyObservers(new LinkChange<TLinkAddress>(null, after, LinkChangeType.Create));
+
+            return result;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Creates a point link and notifies all observers.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <returns>The address of the created link.</returns>
+        public TLinkAddress Create()
+        {
+            // Create a point link (a link that points to itself)
+            var result = _links.GetOrCreate(default(TLinkAddress), default(TLinkAddress));
+
+            // Create the "after" state
+            var after = new TLinkAddress[] { result, _links.GetSource(result), _links.GetTarget(result) };
+
+            // Notify observers about the create operation
+            NotifyObservers(new LinkChange<TLinkAddress>(null, after, LinkChangeType.Create));
+
+            return result;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Updates a link and notifies all observers.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="link">The address of the link to update.</param>
+        /// <param name="newSource">The new source of the link.</param>
+        /// <param name="newTarget">The new target of the link.</param>
+        /// <returns>The address of the updated link.</returns>
+        public TLinkAddress Update(TLinkAddress link, TLinkAddress newSource, TLinkAddress newTarget)
+        {
+            // Get the current state before update
+            var oldSource = _links.GetSource(link);
+            var oldTarget = _links.GetTarget(link);
+            var before = new TLinkAddress[] { link, oldSource, oldTarget };
+
+            // Use Update extension method to update the link
+            var result = _links.Update(link, newSource, newTarget);
+
+            // Create the "after" state
+            var after = new TLinkAddress[] { result, newSource, newTarget };
+
+            // Notify observers about the update operation
+            NotifyObservers(new LinkChange<TLinkAddress>(before, after, LinkChangeType.Update));
+
+            return result;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Deletes a link and notifies all observers.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="link">The address of the link to delete.</param>
+        public void Delete(TLinkAddress link)
+        {
+            // Get the current state before deletion
+            var source = _links.GetSource(link);
+            var target = _links.GetTarget(link);
+            var before = new TLinkAddress[] { link, source, target };
+
+            // Delete the link using the Delete extension method
+            _links.Delete(link);
+
+            // Notify observers about the delete operation
+            NotifyObservers(new LinkChange<TLinkAddress>(before, null, LinkChangeType.Delete));
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<LinkChange<TLinkAddress>> observer)
+        {
+            if (observer == null)
+                throw new ArgumentNullException(nameof(observer));
+
+            lock (_observersLock)
+            {
+                if (!_observers.Contains(observer))
+                    _observers.Add(observer);
+            }
+
+            return new Unsubscriber(_observers, observer, _observersLock);
+        }
+
+        private void NotifyObservers(LinkChange<TLinkAddress> change)
+        {
+            List<IObserver<LinkChange<TLinkAddress>>> observersCopy;
+            lock (_observersLock)
+            {
+                observersCopy = new List<IObserver<LinkChange<TLinkAddress>>>(_observers);
+            }
+
+            foreach (var observer in observersCopy)
+            {
+                try
+                {
+                    observer.OnNext(change);
+                }
+                catch (Exception ex)
+                {
+                    observer.OnError(ex);
+                }
+            }
+        }
+
+        private class Unsubscriber : IDisposable
+        {
+            private readonly List<IObserver<LinkChange<TLinkAddress>>> _observers;
+            private readonly IObserver<LinkChange<TLinkAddress>> _observer;
+            private readonly object _lock;
+
+            public Unsubscriber(List<IObserver<LinkChange<TLinkAddress>>> observers, IObserver<LinkChange<TLinkAddress>> observer, object lockObject)
+            {
+                _observers = observers;
+                _observer = observer;
+                _lock = lockObject;
+            }
+
+            public void Dispose()
+            {
+                lock (_lock)
+                {
+                    if (_observer != null && _observers.Contains(_observer))
+                        _observers.Remove(_observer);
+                }
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/ObservableLinksExampleCLI.cs
+++ b/Platform/Platform.Examples/ObservableLinksExampleCLI.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using Platform.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Specific;
+using Platform.Data.Doublets.Memory.United.Generic;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// <para>
+    /// Demonstrates the subscribe/unsubscribe pattern for link events using IObservable and IObserver.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    public class ObservableLinksExampleCLI : ICommandLineInterface
+    {
+        /// <inheritdoc/>
+        public void Run(params string[] args)
+        {
+            // Create a temporary links database file
+            var tempFile = Path.GetTempFileName();
+
+            try
+            {
+                Console.WriteLine("=== Observable Links Example ===");
+                Console.WriteLine("Demonstrates IObservable/IObserver pattern for link events.");
+                Console.WriteLine();
+
+                using (var links = new UInt64UnitedMemoryLinks(tempFile))
+                {
+                    // Wrap the links with the observable wrapper
+                    var observableLinks = new ObservableLinks<ulong>(links);
+
+                    Console.WriteLine("Creating observers...");
+                    var observer1 = new LinksObserver<ulong>("Observer1");
+                    var observer2 = new LinksObserver<ulong>("Observer2");
+
+                    // Subscribe observers
+                    Console.WriteLine("Subscribing Observer1 and Observer2...");
+                    var subscription1 = observableLinks.Subscribe(observer1);
+                    var subscription2 = observableLinks.Subscribe(observer2);
+                    Console.WriteLine();
+
+                    // Create some links
+                    Console.WriteLine("Creating link 1...");
+                    var link1 = observableLinks.Create();
+                    Console.WriteLine();
+
+                    Console.WriteLine("Creating link 2...");
+                    var link2 = observableLinks.Create();
+                    Console.WriteLine();
+
+                    Console.WriteLine("Creating link 3 (pointing from link1 to link2)...");
+                    var link3 = observableLinks.Create(link1, link2);
+                    Console.WriteLine();
+
+                    // Update a link
+                    Console.WriteLine("Updating link 3 (changing target to link1)...");
+                    observableLinks.Update(link3, link1, link1);
+                    Console.WriteLine();
+
+                    // Unsubscribe observer1
+                    Console.WriteLine("Unsubscribing Observer1...");
+                    subscription1.Dispose();
+                    Console.WriteLine();
+
+                    // Create another link (only observer2 should receive this)
+                    Console.WriteLine("Creating link 4 (only Observer2 should see this)...");
+                    var link4 = observableLinks.Create();
+                    Console.WriteLine();
+
+                    // Delete a link
+                    Console.WriteLine("Deleting link 4...");
+                    observableLinks.Delete(link4);
+                    Console.WriteLine();
+
+                    // Unsubscribe observer2
+                    Console.WriteLine("Unsubscribing Observer2...");
+                    subscription2.Dispose();
+                    Console.WriteLine();
+
+                    // Create one more link (no observers should receive this)
+                    Console.WriteLine("Creating link 5 (no observers subscribed, no output expected)...");
+                    var link5 = observableLinks.Create();
+                    Console.WriteLine("Link 5 created, but no observers were notified.");
+                    Console.WriteLine();
+
+                    Console.WriteLine("=== Example completed successfully ===");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Console.WriteLine(ex.StackTrace);
+            }
+            finally
+            {
+                // Clean up temporary file
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #92

## 🎯 Summary
Implements a subscribe/unsubscribe example for link events using the IObservable/IObserver pattern as requested in issue #92.

## 📝 Implementation Details

### Components Added

1. **LinkChange<T>** (`LinkChange.cs`)
   - Represents a link change event with before/after states
   - Includes `LinkChangeType` enum (Create, Update, Delete)

2. **ObservableLinks<T>** (`ObservableLinks.cs`)
   - IObservable wrapper for ILinks that notifies subscribers of link changes
   - Provides simple Create(), Update(), Delete() methods
   - Thread-safe observer management with proper unsubscription support

3. **LinksObserver<T>** (`LinksObserver.cs`)
   - Example IObserver implementation that logs events to console
   - Can be subclassed for custom behavior

4. **ObservableLinksExampleCLI** (`ObservableLinksExampleCLI.cs`)
   - Complete demonstration of the pattern
   - Shows multiple observers, subscribing, unsubscribing, and event notifications

### Example Usage

```csharp
// Create observable wrapper
var observableLinks = new ObservableLinks<ulong>(links);

// Create and subscribe observers
var observer1 = new LinksObserver<ulong>("Observer1");
var subscription1 = observableLinks.Subscribe(observer1);

// Create links - observer receives notifications
var link1 = observableLinks.Create();
var link2 = observableLinks.Create(link1, link1);

// Unsubscribe
subscription1.Dispose();
```

## ✅ Testing
- ✅ Code builds successfully with no errors or warnings
- ✅ Follows existing code patterns in Platform.Examples
- ✅ Compatible with Platform.Data.Doublets 0.6.10

## 📚 References
- [IObservable Interface](https://learn.microsoft.com/dotnet/api/system.iobservable-1)
- [IObserver Interface](https://learn.microsoft.com/dotnet/api/system.iobserver-1)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)