### PR TITLE
Document all cases of point-pair contradiction and solutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-96-5fee2372
+Your prepared working directory: /tmp/gh-issue-solver-1760635968688
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-96-5fee2372
-Your prepared working directory: /tmp/gh-issue-solver-1760635968688
-
-Proceed.

--- a/doc/articles/point-pair-contradiction.md
+++ b/doc/articles/point-pair-contradiction.md
@@ -1,0 +1,337 @@
+# Point-Pair Contradiction: Cases and Solutions
+
+## Overview
+
+The point-pair contradiction arises from the historical evolution of the Links Platform data model. This document describes all cases where this contradiction manifests and provides solutions or workarounds for each case.
+
+## Historical Context
+
+From the Links Theory document (lines 172-180 in `links-theory.md`):
+
+> "Links could reference other links, allowing the construction of sentence structures of any complexity for effective work with data at the 'semantic level'. But by inertia from graph theory, 'points' or 'elements' were adopted, to which textual descriptions (the values of these elements) were attached - those same sequences, symbol lists. Initially, it was decided, due to the closed source code of Sentences, to simplify the model and develop an open technological solution. Thus, links were allowed to reference themselves. And points ('elements') were completely excluded from the system."
+
+## The Contradiction
+
+The fundamental contradiction is:
+
+**In traditional graph theory**: Points (nodes/vertices) and Pairs (edges/links) are distinct entities
+- Points are the fundamental elements
+- Pairs connect points
+
+**In Links Platform**: Only pairs exist
+- Points were eliminated from the system
+- Links can reference themselves and other links
+- This creates an architectural tension when trying to represent what would traditionally be "point" concepts
+
+## Cases of Point-Pair Contradiction
+
+### Case 1: Self-Referencing Links (Point-Links)
+
+**Description**: A link that references itself represents a "point" in the traditional sense.
+
+**Manifestation**:
+```
+Link: (Self → Self)
+```
+
+From links-theory.md line 346:
+> "A 'full point' or simply 'point' is such a link where both references point to itself."
+
+**Problems**:
+- Semantic ambiguity: Is it a point or a pair?
+- Identity confusion: The point and the pair describing it are the same entity
+- Violates separation of concerns
+
+**Solutions**:
+
+1. **Accept the duality**: Recognize that point-links are a valid construct where a link simultaneously represents both a node and an edge to itself
+   - Use: `link = links.Update(link, newSource: link, newTarget: link)`
+   - Advantage: Minimal storage overhead
+   - Disadvantage: Conceptual complexity
+
+2. **Explicit point markers**: Create a special "Point" link type that all point-links reference
+   - Create a designated point marker link
+   - All self-referencing links reference this marker instead of themselves
+   - Advantage: Clearer semantic meaning
+   - Disadvantage: Extra indirection
+
+3. **Virtual points layer**: Maintain a conceptual layer that treats certain links as points
+   - Implement helper functions that identify point-links
+   - Provide API that abstracts the point/pair distinction
+   - Advantage: Clean API for users
+   - Disadvantage: Maintaining two mental models
+
+### Case 2: Partial Points
+
+**Description**: A link where only one reference points to itself, and the other points to a different link.
+
+**Manifestation**:
+```
+Link: (Self → Other) or (Other → Self)
+```
+
+From links-theory.md line 346:
+> "A 'partial point' is considered such a link where only one reference points to itself, and the other necessarily to another link."
+
+**Problems**:
+- Hybrid entity: Neither pure point nor pure pair
+- Ambiguous directionality: Which reference matters?
+- Complex traversal logic
+
+**Solutions**:
+
+1. **Treat as edges with anchors**: Interpret partial points as edges that are anchored at one end
+   - Source=Self: Outgoing edge from a point-like entity
+   - Target=Self: Incoming edge to a point-like entity
+   - Advantage: Preserves directional semantics
+   - Disadvantage: Still conceptually mixed
+
+2. **Normalize to full pairs**: Transform partial points into full pairs by creating an explicit point-link
+   - Replace `(Self → Other)` with `(Point → Other)` where Point is a full point-link
+   - Advantage: Eliminates ambiguity
+   - Disadvantage: Increases link count
+
+3. **Use as transition states**: Allow partial points only as temporary states during construction
+   - During link creation, briefly allow partial points
+   - Always resolve to full pairs or full points before persistence
+   - Advantage: Simplifies final data model
+   - Disadvantage: More complex creation logic
+
+### Case 3: Representing Traditional Graph Nodes
+
+**Description**: When importing or interfacing with traditional graph structures where nodes have identity independent of edges.
+
+**Manifestation**:
+- External system has Node(id=1, data="A") and Edge(from=1, to=2)
+- Links Platform needs to represent this
+
+**Problems**:
+- No native node concept
+- Node properties need attachment points
+- Node identity vs. link identity mismatch
+
+**Solutions**:
+
+1. **Node-as-point-link pattern**: Create point-links for each node
+   ```
+   NodeLink = Create() // Full point: (Self → Self)
+   DataLink = Create(NodeLink, DataValue)
+   EdgeLink = Create(Node1, Node2) // Regular pair
+   ```
+   - Advantage: Clean separation of nodes and edges
+   - Disadvantage: Doubled entity count
+
+2. **Implicit nodes**: Derive node existence from edge references
+   - Only create pair links
+   - Nodes are implicit from unique link references
+   - Use indexes to track "which links represent nodes"
+   - Advantage: Minimal storage
+   - Disadvantage: Requires external metadata
+
+3. **Hybrid storage**: Use point-links for nodes with properties, implicit for nodes without
+   - Create point-links only when nodes have attached data
+   - Leave nodes without properties implicit
+   - Advantage: Balances storage and semantics
+   - Disadvantage: Inconsistent representation
+
+### Case 4: Connecting Two Separate Points
+
+**Description**: From lines 325-326 in links-theory.md regarding single links:
+
+> "In all cases it will be impossible to connect two separate points or two separate synonyms."
+
+This limitation of single-reference links highlights why the system needs pairs (double links).
+
+**Manifestation**:
+- Need to connect two independent entities
+- Single links cannot form proper binary relationships
+- Point-links cannot directly connect to other point-links without an intermediate pair-link
+
+**Problems**:
+- Cannot directly connect two self-referencing links
+- Requires pair-link intermediary
+- Creates minimum structure requirements
+
+**Solutions**:
+
+1. **Always use pair-links for connections**: The fundamental solution
+   ```
+   Point1 = Create(Point1, Point1)  // Full point
+   Point2 = Create(Point2, Point2)  // Full point
+   Connection = Create(Point1, Point2)  // Pair connecting them
+   ```
+   - Advantage: This is the intended design
+   - Disadvantage: None, this is the correct approach
+
+2. **Connection as shared reference**: Both points reference a common intermediate
+   ```
+   Intermediate = Create()
+   Point1 = Create(Point1, Intermediate)  // Partial point
+   Point2 = Create(Point2, Intermediate)  // Partial point
+   ```
+   - Advantage: Fewer total links in some cases
+   - Disadvantage: Loss of direct connection semantics
+
+### Case 5: Sequence Elements vs. Pair Structure
+
+**Description**: Sequences are built from pairs, but elements in sequences might be conceptualized as "points" in the sequence.
+
+**Manifestation**:
+- Sequence [A, B, C, D] represented as nested pairs
+- Elements A, B, C, D could be point-links or references to existing links
+- The pair structure creates the sequence, but elements are the "points of interest"
+
+**Problems**:
+- Elements might be conflated with the pairs that structure them
+- Accessing "element at position N" requires understanding pair structure
+- Same element in multiple sequences: should it be a point-link or duplicated?
+
+**Solutions**:
+
+1. **Elements as separate entities**: Always use distinct links for sequence elements
+   ```
+   A = Create()  // Element (could be point-link or pair)
+   B = Create()  // Element
+   Seq = Create(A, B)  // Sequence pair
+   ```
+   - Advantage: Elements can be reused across sequences
+   - Disadvantage: More links
+
+2. **Elements as literals**: Some elements (especially primitives) can be embedded
+   - Use numeric link addresses as literals for small integers
+   - Reserve address ranges for common values
+   - Advantage: Very compact representation
+   - Disadvantage: Limited to predefined values
+
+3. **Hybrid approach**: Points for reusable entities, pairs for structure
+   - Named entities, types, constants: point-links
+   - Structure, relationships, sequences: pair-links
+   - Advantage: Semantic clarity
+   - Disadvantage: Requires convention enforcement
+
+### Case 6: Empty or Null Values
+
+**Description**: Representing absence, null, or empty values in a system where everything is a link.
+
+**Manifestation**:
+- Need to represent "no value" or "empty"
+- Traditional null doesn't exist
+- Everything must be a link reference
+
+**Problems**:
+- How to distinguish "link to nothing" from "no link"?
+- Is empty a point (self-reference) or absence (special value)?
+- Null reference exceptions vs. links to null-representing links
+
+**Solutions**:
+
+1. **Designated null point-link**: Create a special link that represents null
+   ```
+   NullLink = Create(NullLink, NullLink)  // The "null" point
+   ```
+   - Use this link wherever null would be used
+   - Advantage: Consistent link-based representation
+   - Disadvantage: Null still exists, just as a link
+
+2. **Use zero or reserved addresses**: Reserve link address 0 or specific range for null
+   - Check for zero address to detect null
+   - Never create link with reserved address
+   - Advantage: Efficient check
+   - Disadvantage: Platform-specific
+
+3. **Optional pattern**: Create explicit "Some" and "None" constructors
+   ```
+   SomeType = Create(...)  // Type marker
+   NoneValue = Create(NoneMarker, SomeType)
+   SomeValue = Create(SomeMarker, Create(SomeType, ActualValue))
+   ```
+   - Advantage: Type-safe nullability
+   - Disadvantage: Verbose
+
+## General Workarounds
+
+### Workaround 1: Type Systems
+
+Implement a type system that distinguishes point-links from pair-links at a higher level:
+
+```csharp
+// Conceptual example
+var pointType = links.Create();  // Type marker for points
+var pairType = links.Create();   // Type marker for pairs
+
+var point = links.Create(point, point);
+var pointMetadata = links.Create(point, pointType);  // Mark as point
+
+var pair = links.Create(point1, point2);
+var pairMetadata = links.Create(pair, pairType);  // Mark as pair
+```
+
+### Workaround 2: Convention Over Configuration
+
+Establish conventions:
+- Links with both references equal: treated as points
+- Links with different references: treated as pairs
+- Document and enforce in code reviews
+
+### Workaround 3: Abstraction Layers
+
+Create API layers that hide the contradiction:
+
+```csharp
+// High-level API
+interface IGraph {
+    Node CreateNode();
+    Edge CreateEdge(Node from, Node to);
+}
+
+// Implementation maps to links
+class GraphOverLinks : IGraph {
+    ILinks links;
+
+    Node CreateNode() {
+        var link = links.Create();
+        return new Node(links.Update(link, link, link));
+    }
+
+    Edge CreateEdge(Node from, Node to) {
+        return new Edge(links.Create(from.Link, to.Link));
+    }
+}
+```
+
+### Workaround 4: External Metadata
+
+Maintain external indices or metadata stores:
+- Keep a separate structure tracking which links are "conceptual points"
+- Use this for queries and traversals
+- Update atomically with link operations
+
+## Recommendations
+
+1. **For new systems**: Embrace the point-free philosophy. Use pairs exclusively and let points emerge as self-referencing links only when semantically necessary.
+
+2. **For graph imports**: Use node-as-point-link pattern (Solution 1 in Case 3) for clarity and correctness.
+
+3. **For sequences**: Treat elements as distinct from structure (Solution 1 in Case 5).
+
+4. **For null handling**: Use designated null point-link (Solution 1 in Case 6) for consistency.
+
+5. **Document your choice**: Whatever approach you use, document it clearly for maintainers.
+
+## Conclusion
+
+The point-pair contradiction is not a flaw but a fundamental design choice in Links Platform: eliminating points in favor of a pure pair-based system. The "contradiction" arises when interfacing with traditional graph thinking or when implementing features that conceptually rely on point/node identity.
+
+All cases can be resolved by:
+1. Accepting self-referencing links as points
+2. Creating explicit conventions
+3. Building abstraction layers
+4. Maintaining external metadata
+
+The key is recognizing when you're thinking in terms of "points" and consciously translating that into the pair-based Links model.
+
+## References
+
+- [Links Theory Document](links-theory.md) - Sections on empty links, single links, and double links
+- [Platform.Data.Doublets](https://github.com/linksplatform/Data.Doublets) - Primary implementation
+- Issue #96 - This documentation issue


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #96

## 📝 Summary

This PR provides comprehensive documentation of the point-pair contradiction in Links Platform and solutions for all identified cases.

## 🔍 What is the Point-Pair Contradiction?

The point-pair contradiction arises from a fundamental design choice in Links Platform: **the elimination of "points" (nodes) in favor of a pure pair-based system**.

From the historical context:
> In traditional graph theory, "points" or "elements" were adopted from graph theory. Links Platform made the decision to completely exclude points from the system, allowing links to reference themselves instead.

## 📚 Documentation Added

New file: [`doc/articles/point-pair-contradiction.md`](https://github.com/konard/LinksPlatform/blob/issue-96-5fee2372/doc/articles/point-pair-contradiction.md)

### Six Cases Documented

1. **Self-Referencing Links (Point-Links)**: Links where both references point to itself - the "full point" case
2. **Partial Points**: Links where only one reference points to itself
3. **Representing Traditional Graph Nodes**: Importing/interfacing with traditional graph structures
4. **Connecting Two Separate Points**: The fundamental limitation of single-reference links
5. **Sequence Elements vs. Pair Structure**: Elements in sequences built from pairs
6. **Empty or Null Values**: Representing absence in a link-only system

### Solutions Provided

For each case, the documentation provides:
- ✅ Multiple solution approaches
- ✅ Advantages and disadvantages of each
- ✅ Code examples (where applicable)
- ✅ Recommendations for different use cases

### General Workarounds

1. **Type Systems**: Distinguish point-links from pair-links at a higher level
2. **Convention Over Configuration**: Establish and enforce conventions
3. **Abstraction Layers**: Create APIs that hide the contradiction
4. **External Metadata**: Maintain separate tracking structures

## 🎯 Key Findings

The "contradiction" is not a flaw but emerges when:
- Interfacing with traditional graph thinking
- Implementing features that conceptually rely on point/node identity
- Importing data from node-edge graph systems

All cases can be resolved by:
1. Accepting self-referencing links as points
2. Creating explicit conventions
3. Building abstraction layers
4. Maintaining external metadata

## 🔧 Technical Details

The documentation is based on analysis of:
- The Links Theory document (`doc/articles/links-theory.md`)
- Platform.Data.Doublets implementation
- Historical evolution from graph theory to pure link-based model

## ✅ Recommendations

1. **For new systems**: Embrace the point-free philosophy
2. **For graph imports**: Use node-as-point-link pattern
3. **For sequences**: Treat elements as distinct from structure
4. **For null handling**: Use designated null point-link
5. **Document your choice**: Whatever approach you use, document it clearly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>