### PR TITLE
Add documentation on global object collections (Schema.org, Wikidata)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-97-751cd2c6
+Your prepared working directory: /tmp/gh-issue-solver-1760636421189
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-97-751cd2c6
-Your prepared working directory: /tmp/gh-issue-solver-1760636421189
-
-Proceed.

--- a/doc/articles/global-objects-collection.md
+++ b/doc/articles/global-objects-collection.md
@@ -1,0 +1,419 @@
+# Global Collection of Objects: Structure, Behaviour, Standards, and APIs
+
+## Overview
+
+This document explores the concept of a global collection of objects, focusing on standardized approaches to structuring, describing, and accessing information about entities in a machine-readable format. It examines established standards like Schema.org and Wikidata, and discusses how these relate to the LinksPlatform's associative data model.
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Schema.org: Structured Data Vocabularies](#schemaorg-structured-data-vocabularies)
+* [Wikidata: Collaborative Knowledge Base](#wikidata-collaborative-knowledge-base)
+* [Comparison and Integration](#comparison-and-integration)
+* [Inferring Structure from Natural Language](#inferring-structure-from-natural-language)
+* [Relevance to LinksPlatform](#relevance-to-linksplatform)
+* [References and Resources](#references-and-resources)
+
+## Introduction
+
+The concept of a "global collection of objects" represents an ambitious goal: creating a unified, machine-readable repository of structured information about entities, their properties, and relationships. This vision has been partially realized through various initiatives that provide:
+
+- **Standardized vocabularies** for describing entities and their properties
+- **APIs and protocols** for accessing and querying structured data
+- **Collaborative frameworks** for building and maintaining knowledge bases
+- **Semantic web technologies** for linking and inferring relationships
+
+Two prominent examples of such systems are Schema.org and Wikidata, each approaching the problem from different angles but sharing the common goal of making structured information more accessible.
+
+## Schema.org: Structured Data Vocabularies
+
+### What is Schema.org?
+
+Schema.org is a collaborative initiative founded in 2011 by Google, Microsoft, Yahoo, and Yandex to create and maintain a shared vocabulary for structured data markup on the web. As of 2024, over 45 million web domains use Schema.org to markup their web pages with over 450 billion Schema.org objects.
+
+### Key Characteristics
+
+**Standardized Vocabulary**: Schema.org provides a hierarchical taxonomy of types (e.g., Person, Organization, Product, Event) and properties (e.g., name, description, startDate) that can be used to describe entities.
+
+**Multiple Encoding Formats**: The vocabulary can be embedded in web pages using various formats:
+- **RDFa** (Resource Description Framework in Attributes)
+- **Microdata** (HTML5 standard)
+- **JSON-LD** (JSON for Linking Data) - currently the most popular format
+
+**Extensibility**: The vocabulary is designed to be extended through:
+- Community extensions for specific domains
+- Hosted extensions for experimental types
+- External extensions maintained by third parties
+
+### Use Cases
+
+1. **Search Engine Optimization**: Rich snippets and enhanced search results
+2. **E-commerce**: Product information, pricing, availability
+3. **Events**: Calendar integration and event discovery
+4. **Local Business**: Business hours, location, contact information
+5. **Content Publishing**: Article metadata, author information, publication dates
+
+### Example: Person Entity
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Jane Doe",
+  "jobTitle": "Software Engineer",
+  "email": "jane.doe@example.com",
+  "telephone": "+1-555-555-5555",
+  "url": "https://example.com/jane-doe",
+  "sameAs": [
+    "https://www.linkedin.com/in/janedoe",
+    "https://twitter.com/janedoe"
+  ]
+}
+```
+
+### API Access
+
+While Schema.org itself is primarily a vocabulary specification, the structured data it describes can be:
+- Extracted from web pages using structured data parsers
+- Accessed through search engine APIs that understand Schema.org markup
+- Integrated into knowledge graphs and semantic search systems
+
+## Wikidata: Collaborative Knowledge Base
+
+### What is Wikidata?
+
+Wikidata is a free, collaborative knowledge base that serves as central storage for the structured data of Wikimedia projects (including Wikipedia, Wikimedia Commons, and others). It currently contains over 119 million data items that can be edited by both humans and machines.
+
+### Key Characteristics
+
+**Collaborative Editing**: Like Wikipedia, Wikidata is built and maintained by volunteers worldwide, with robust versioning and quality control mechanisms.
+
+**Multilingual by Design**: All labels, descriptions, and aliases can be provided in multiple languages, making the data truly international.
+
+**Structured Properties**: Each item has:
+- **Statements**: Claims about the item (e.g., "born in Paris" or "instance of human")
+- **Qualifiers**: Additional context for statements
+- **References**: Sources supporting the statements
+- **Ranks**: Indicating preferred or deprecated values
+
+**Free and Open License**: All data is available under CC0 (Creative Commons Zero), allowing unrestricted use.
+
+### Data Model
+
+Wikidata uses a flexible triple-based model enhanced with qualifiers and references:
+
+```
+Item → Property → Value
+  ↓        ↓         ↓
+  ↓    Qualifiers    ↓
+  ↓    References    ↓
+  ↓    Rank          ↓
+```
+
+### Example: Ada Lovelace (Q7259)
+
+```
+Item: Ada Lovelace (Q7259)
+  - instance of (P31): human (Q5)
+  - sex or gender (P21): female (Q6581072)
+  - date of birth (P569): 10 December 1815
+    - place of birth (P19): London (Q84)
+  - date of death (P570): 27 November 1852
+    - place of death (P20): Marylebone (Q1166109)
+  - occupation (P106): mathematician (Q170790), computer scientist (Q82594)
+  - known for (P800): Analytical Engine (Q677800)
+```
+
+### API Access
+
+Wikidata provides comprehensive API access:
+
+**MediaWiki API**: Full read/write access to Wikidata content
+```
+https://www.wikidata.org/w/api.php
+```
+
+**Wikidata Query Service (SPARQL)**: Powerful query interface for complex searches
+```sparql
+SELECT ?person ?personLabel ?birthDate WHERE {
+  ?person wdt:P31 wd:Q5 .           # instance of human
+  ?person wdt:P106 wd:Q82594 .       # occupation: computer scientist
+  ?person wdt:P569 ?birthDate .      # has birth date
+  FILTER(?birthDate < "1900-01-01"^^xsd:dateTime)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+```
+
+**Linked Data Interface**: Direct access to individual items as RDF
+```
+https://www.wikidata.org/wiki/Special:EntityData/Q7259.json
+```
+
+**REST API**: Modern RESTful interface for common operations
+```
+https://www.wikidata.org/w/rest.php/wikibase/v0/entities/items/Q7259
+```
+
+## Comparison and Integration
+
+### Schema.org vs. Wikidata
+
+| Aspect | Schema.org | Wikidata |
+|--------|-----------|----------|
+| **Purpose** | Vocabulary for web markup | Collaborative knowledge base |
+| **Governance** | Consortium (Google, Microsoft, etc.) | Wikimedia Foundation + community |
+| **Data Storage** | Distributed (embedded in websites) | Centralized (Wikidata database) |
+| **Update Model** | Website owners update their markup | Community edits through interface/API |
+| **Coverage** | Broad but shallow (millions of sites) | Deep but selective (millions of items) |
+| **Language Support** | Vocabulary labels in multiple languages | Full multilingual support for all data |
+| **Querying** | Through search engines and parsers | Direct SPARQL queries |
+| **License** | Vocabulary is open (CC BY-SA 3.0) | Data is CC0 (public domain) |
+
+### Integration Opportunities
+
+**Mapping Between Systems**: Schema.org types and properties can be mapped to Wikidata items and properties:
+```
+schema:Person → wdt:Q5 (human)
+schema:Organization → wdt:Q43229 (organization)
+schema:Place → wdt:Q618123 (geographical location)
+```
+
+**Enrichment**: Web pages with Schema.org markup can link to corresponding Wikidata items using `sameAs`:
+```json
+{
+  "@type": "Person",
+  "name": "Ada Lovelace",
+  "sameAs": "https://www.wikidata.org/wiki/Q7259"
+}
+```
+
+**Complementary Use Cases**:
+- Schema.org: Describing content and entities on individual websites
+- Wikidata: Providing canonical identifiers and detailed background information
+- Together: Creating a distributed knowledge graph spanning the entire web
+
+## Inferring Structure from Natural Language
+
+### The Challenge
+
+One of the most ambitious goals in knowledge representation is automatically extracting structured data from unstructured text. This involves:
+
+1. **Named Entity Recognition (NER)**: Identifying entities (people, places, organizations) in text
+2. **Relation Extraction**: Determining relationships between entities
+3. **Entity Linking**: Mapping extracted entities to canonical identifiers (e.g., Wikidata IDs)
+4. **Schema Mapping**: Converting informal descriptions to formal schemas
+
+### Current Approaches
+
+**Rule-Based Systems**: Use linguistic patterns and domain knowledge
+- Regular expressions for structured formats
+- Dependency parsing for relationship extraction
+- Template-based information extraction
+
+**Machine Learning**: Statistical models trained on annotated data
+- Supervised learning with labeled examples
+- Semi-supervised learning with minimal annotations
+- Transfer learning from pre-trained language models
+
+**Large Language Models (LLMs)**: Modern neural networks like GPT, BERT, and their variants
+- Few-shot learning with examples in prompts
+- Zero-shot extraction from natural language instructions
+- Fine-tuning on domain-specific tasks
+
+### Example Pipeline
+
+```
+Input Text:
+"Ada Lovelace was born in London on December 10, 1815. She was a mathematician
+and is often regarded as the first computer programmer."
+
+↓ Named Entity Recognition
+
+Entities:
+- Ada Lovelace (PERSON)
+- London (PLACE)
+- December 10, 1815 (DATE)
+- mathematician (OCCUPATION)
+- computer programmer (OCCUPATION)
+
+↓ Entity Linking
+
+Wikidata Items:
+- Ada Lovelace → Q7259
+- London → Q84
+- mathematician → Q170790
+- computer scientist → Q82594
+
+↓ Relation Extraction
+
+Relationships:
+- Ada Lovelace → birth_place → London
+- Ada Lovelace → birth_date → 1815-12-10
+- Ada Lovelace → occupation → mathematician
+- Ada Lovelace → occupation → computer scientist
+
+↓ Schema.org Output
+
+{
+  "@type": "Person",
+  "@id": "https://www.wikidata.org/wiki/Q7259",
+  "name": "Ada Lovelace",
+  "birthPlace": {
+    "@type": "Place",
+    "@id": "https://www.wikidata.org/wiki/Q84",
+    "name": "London"
+  },
+  "birthDate": "1815-12-10",
+  "jobTitle": ["mathematician", "computer programmer"]
+}
+```
+
+### Frameworks and Tools
+
+**spaCy**: Industrial-strength NLP library with NER and entity linking
+```python
+import spacy
+nlp = spacy.load("en_core_web_sm")
+doc = nlp("Ada Lovelace was born in London.")
+for ent in doc.ents:
+    print(ent.text, ent.label_)
+```
+
+**Stanford CoreNLP**: Suite of NLP tools including relation extraction
+
+**Hugging Face Transformers**: Pre-trained models for various NLP tasks
+```python
+from transformers import pipeline
+ner = pipeline("ner", model="dslim/bert-base-NER")
+results = ner("Ada Lovelace was born in London.")
+```
+
+**DBpedia Spotlight**: Entity linking to DBpedia/Wikidata
+```
+curl -X POST "https://api.dbpedia-spotlight.org/en/annotate" \
+  -H "Accept: application/json" \
+  -d "text=Ada Lovelace was born in London."
+```
+
+## Relevance to LinksPlatform
+
+### Associative Model and Knowledge Representation
+
+LinksPlatform's core is based on an associative model using doublets (binary links) that can represent any data structure. This model has natural synergies with global object collections:
+
+**Universal Representation**: Both Schema.org triples and Wikidata statements can be represented as links in the LinksPlatform:
+```
+[Subject] → [Predicate] → [Object]
+    ↓           ↓            ↓
+[Link_1] → [Link_2] → [Link_3]
+```
+
+**Semantic Web Compatibility**: RDF triples used by both systems map directly to doublets:
+- Subject-Predicate-Object can be stored as nested doublet structures
+- Qualifiers and metadata can be represented as additional links
+
+**Flexible Schema**: LinksPlatform's schema-agnostic approach allows:
+- Storing Schema.org and Wikidata entities side-by-side
+- Dynamic schema evolution as standards change
+- Cross-referencing between different knowledge bases
+
+### Potential Integration Scenarios
+
+**1. Schema.org Import/Export**
+```
+LinksPlatform ↔ Schema.org JSON-LD
+- Parse JSON-LD into link structure
+- Query links and generate Schema.org output
+- Validate against Schema.org vocabulary
+```
+
+**2. Wikidata Synchronization**
+```
+LinksPlatform ↔ Wikidata API
+- Import Wikidata items as link networks
+- Track changes and maintain synchronization
+- Contribute back structured data from links
+```
+
+**3. Natural Language Processing**
+```
+Text → NLP Pipeline → Link Structure
+- Extract entities and relationships from text
+- Create links representing extracted knowledge
+- Link to Schema.org/Wikidata identifiers
+```
+
+**4. Hybrid Knowledge Graph**
+```
+Local Links + External References
+- Store frequently accessed data locally as links
+- Maintain references to Schema.org/Wikidata
+- Query across local and external sources
+```
+
+### Benefits of Integration
+
+**Standardization**: Leverage existing vocabularies and identifiers rather than creating custom schemas
+
+**Interoperability**: Exchange data with systems that understand Schema.org or Wikidata
+
+**Rich Context**: Access detailed information from global knowledge bases to enrich local data
+
+**Community Knowledge**: Benefit from collaborative curation of data quality in Wikidata
+
+**Search Visibility**: Generate Schema.org markup for better discoverability
+
+## References and Resources
+
+### Schema.org
+
+- Official Website: https://schema.org/
+- Documentation: https://schema.org/docs/documents.html
+- GitHub Repository: https://github.com/schemaorg/schemaorg
+- Validator: https://validator.schema.org/
+- Community: https://www.w3.org/community/schemaorg/
+
+### Wikidata
+
+- Official Website: https://www.wikidata.org/
+- Data Model: https://www.wikidata.org/wiki/Wikidata:Data_model
+- SPARQL Query Service: https://query.wikidata.org/
+- API Documentation: https://www.wikidata.org/wiki/Wikidata:Data_access
+- Developer Hub: https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual
+
+### Related Standards and Technologies
+
+- **RDF (Resource Description Framework)**: https://www.w3.org/RDF/
+- **SPARQL (SPARQL Protocol and RDF Query Language)**: https://www.w3.org/TR/sparql11-query/
+- **JSON-LD (JSON for Linking Data)**: https://json-ld.org/
+- **Linked Open Data**: https://www.w3.org/wiki/SweoIG/TaskForces/CommunityProjects/LinkingOpenData
+- **DBpedia**: https://www.dbpedia.org/
+- **YAGO (Yet Another Great Ontology)**: https://yago-knowledge.org/
+
+### Academic Resources
+
+- Ehrlinger, L., & Wöß, W. (2016). Towards a Definition of Knowledge Graphs. *SEMANTiCS (Posters, Demos, SuCCESS)*.
+- Hogan, A., et al. (2021). Knowledge Graphs. *ACM Computing Surveys*, 54(4), 1-37.
+- Paulheim, H. (2017). Knowledge graph refinement: A survey of approaches and evaluation methods. *Semantic Web*, 8(3), 489-508.
+
+### Tools and Libraries
+
+- **Apache Jena**: Framework for building Semantic Web and Linked Data applications
+- **RDFLib**: Python library for working with RDF
+- **Pyshacl**: SHACL validation for RDF graphs in Python
+- **Wikidata Toolkit**: Java library for accessing Wikidata
+- **SPARQLWrapper**: Python library for querying SPARQL endpoints
+- **extruct**: Extract structured data from HTML pages
+
+## Conclusion
+
+The vision of a global collection of objects is being realized through collaborative efforts like Schema.org and Wikidata. These systems provide complementary approaches to structuring, describing, and accessing information:
+
+- **Schema.org** offers a distributed model where structured data lives alongside content on individual websites
+- **Wikidata** provides a centralized, collaboratively curated knowledge base with rich querying capabilities
+
+Together, they form a foundation for building intelligent systems that can understand, process, and reason about information in machine-readable formats.
+
+For LinksPlatform, these standards represent both an opportunity and a challenge: How can an associative data model built on doublets effectively integrate with and leverage these existing global knowledge infrastructures? The answer lies in recognizing that the fundamental patterns of knowledge representation—entities, properties, and relationships—map naturally to link structures, making LinksPlatform a potential universal adapter between different knowledge representation schemes.
+
+As natural language processing and machine learning technologies continue to advance, the ability to automatically infer structure from unstructured text will become increasingly important, bridging the gap between human-readable content and machine-processable knowledge graphs. LinksPlatform's flexible, schema-agnostic approach positions it well to participate in this evolving ecosystem of global structured knowledge.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation on global collection of objects, covering structure, behavior, standards, and APIs with focus on Schema.org and Wikidata.

### Changes

- **New Documentation**: Created `doc/articles/global-objects-collection.md` covering:
  - Schema.org: Structured data vocabularies for web markup
  - Wikidata: Collaborative knowledge base with SPARQL query capabilities
  - Comparison and integration opportunities between both systems
  - Natural language processing approaches for inferring structure
  - Integration scenarios with LinksPlatform's associative model
  - Extensive references, tools, and resources

### Key Topics Covered

1. **Schema.org**
   - Standardized vocabulary for describing entities and properties
   - Multiple encoding formats (JSON-LD, RDFa, Microdata)
   - Use cases for SEO, e-commerce, events, and content publishing
   - API access and integration approaches

2. **Wikidata**
   - Collaborative, multilingual knowledge base with 119M+ items
   - Structured data model with statements, qualifiers, and references
   - Multiple API endpoints (MediaWiki API, SPARQL, REST, Linked Data)
   - Free and open license (CC0)

3. **Integration with LinksPlatform**
   - Mapping between RDF triples and doublet structures
   - Import/export scenarios for Schema.org and Wikidata
   - NLP pipeline for extracting structured data from text
   - Benefits of leveraging global standards

4. **Natural Language Processing**
   - Frameworks and tools for structure inference
   - Entity recognition, relation extraction, and entity linking
   - Example pipeline from text to structured data

### References

Fixes #97

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)