### PR TITLE
Add donation buttons to Support section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-99-c8a05e23
-Your prepared working directory: /tmp/gh-issue-solver-1760636520186
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-99-c8a05e23
+Your prepared working directory: /tmp/gh-issue-solver-1760636520186
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 # LinksPlatform ([русская версия](https://github.com/Konard/LinksPlatform/blob/master/README.ru.md))
 
 English version of this README page is moved to [our organization's page](https://github.com/linksplatform).
+
+## Support
+
+[![PayPal donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=WEQAZXFHZTY76)
+[![Flattr donate button](https://img.shields.io/badge/flattr-donate-yellow.svg)](https://flattr.com/@konard)
+[![Bitcoin donate button](https://img.shields.io/badge/bitcoin-donate-yellow.svg)](https://github.com/konard)

--- a/README.ru.md
+++ b/README.ru.md
@@ -100,6 +100,10 @@ links.Delete(link);
 
 ## Support
 
+[![PayPal donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=WEQAZXFHZTY76)
+[![Flattr donate button](https://img.shields.io/badge/flattr-donate-yellow.svg)](https://flattr.com/@konard)
+[![Bitcoin donate button](https://img.shields.io/badge/bitcoin-donate-yellow.svg)](https://github.com/konard)
+
 Задавайте вопросы по адресу [stackoverflow.com/tags/links-platform](https://stackoverflow.com/tags/links-platform) (или с тегом `links-platform`) чтобы получить нашу бесплатную поддержку.
 
 Вы так же можете получить поддержку в режиме реального времени на [нашем официальном Discord сервере](https://discord.gg/eEXJyjWv5e).


### PR DESCRIPTION
## Summary
Added donation buttons (PayPal, Flattr, and Bitcoin) to the Support section in both README.md and README.ru.md.

## Changes
- Added Support section with three donation buttons to README.md (English version)
- Added donation buttons to existing Support section in README.ru.md (Russian version)
- Used badge-style buttons following the example from the referenced docpad repository

## Fixes
Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)