### PR TITLE
Add timestamp consistency check for transaction log reopening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-103-48ffb6f6
-Your prepared working directory: /tmp/gh-issue-solver-1760638008970
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-103-48ffb6f6
+Your prepared working directory: /tmp/gh-issue-solver-1760638008970
+
+Proceed.

--- a/Platform/Platform.Sandbox/Transactions.cs
+++ b/Platform/Platform.Sandbox/Transactions.cs
@@ -97,6 +97,27 @@ namespace Platform.Sandbox
             }
         }
 
+        static void ValidateTransactionTimestamps()
+        {
+            var currentTime = DateTime.UtcNow;
+            var offset = _basicTransactionsOffset;
+            var endOffset = _currentState.FileEndOffset;
+
+            while (offset < endOffset)
+            {
+                _logAccessor.Read(offset, out TransactionItem item);
+
+                if (item.DateTime > currentTime)
+                {
+                    throw new InvalidOperationException(
+                        $"Transaction log consistency check failed: Found timestamp {item.DateTime:O} in the future at offset {offset}. " +
+                        $"Current time: {currentTime:O}. This indicates corrupted data or clock issues.");
+                }
+
+                offset += _transactionItemSize;
+            }
+        }
+
         static void StoreState() => _logAccessor.Write(0, ref _currentState);
 
         static void EnsureFileSize()
@@ -139,7 +160,8 @@ namespace Platform.Sandbox
                 sizeInBytes = _basicTransactionsOffset;
             }
             long savedSizeInBytes = 0;
-            if (File.Exists(TransactionsFileName))
+            bool isExistingFile = File.Exists(TransactionsFileName);
+            if (isExistingFile)
             {
                 var fileInfo = new FileInfo(TransactionsFileName);
                 savedSizeInBytes = fileInfo.Length;
@@ -151,6 +173,13 @@ namespace Platform.Sandbox
             _log = MemoryMappedFile.CreateFromFile(TransactionsFileName, FileMode.OpenOrCreate, TransactionsMapName, sizeInBytes);
             _logAccessor = _log.CreateViewAccessor();
             LoadState();
+
+            // Validate timestamps if opening an existing transaction log
+            if (isExistingFile && savedSizeInBytes > _basicTransactionsOffset)
+            {
+                ValidateTransactionTimestamps();
+            }
+
             _currentFileSizeInBytes = sizeInBytes;
         }
 


### PR DESCRIPTION
## Summary

This PR implements a consistency check for transaction log timestamps when reopening an existing transaction log file, as requested in issue #103.

## Changes

- **Added `ValidateTransactionTimestamps()` method**: Iterates through all transaction items in the log and validates that their timestamps are not in the future
- **Modified `OpenFile()` method**: Now checks if opening an existing file with data and calls the validation method
- **Error handling**: Throws `InvalidOperationException` with detailed diagnostic information if future timestamps are detected

## Implementation Details

The validation is only performed when:
1. The transaction log file already exists
2. The file contains actual transaction data (size > basic header offset)

This ensures:
- New files are not unnecessarily validated
- System clock issues or data corruption are detected early
- Detailed error messages help diagnose the root cause

## Testing

- Built the solution successfully with no compilation errors
- The validation runs automatically when reopening transaction logs
- Exception thrown includes: timestamp value, current time, and offset for debugging

Fixes #103

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)