### PR TITLE
Rename project from LinksPlatform to Linkform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-113-30daf160
-Your prepared working directory: /tmp/gh-issue-solver-1760640617896
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-113-30daf160
+Your prepared working directory: /tmp/gh-issue-solver-1760640617896
+
+Proceed.

--- a/docfx.json
+++ b/docfx.json
@@ -30,7 +30,7 @@
       }
     ],
     "globalMetadata": {
-      "_appTitle": "LinksPlatform",
+      "_appTitle": "Linkform",
       "_enableSearch": true
     },
     "dest": "doc/generated/site"

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# Links Platform ([русская версия](index.ru.md))
+# Linkform ([русская версия](index.ru.md))
 Holistic system for storage and transformation of information (in development) based on associative model of data.
 
 ## Prerequisites
@@ -6,7 +6,7 @@ Holistic system for storage and transformation of information (in development) b
 * [.NET Core](https://www.microsoft.com/net) SDK with version 2.2 or later.
 * [MonoDevelop](https://www.monodevelop.com/), [Visual Studio](https://visualstudio.microsoft.com) or any other [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment) or just a [text editor](https://en.wikipedia.org/wiki/Text_editor).
 
-## Links Platform's NuGet packages
+## Linkform's NuGet packages
 
 ### Main packages
 

--- a/index.ru.md
+++ b/index.ru.md
@@ -1,4 +1,4 @@
-# Платформа Связей ([english version](index.md))
+# Linkform ([english version](index.md))
 Целостная система для хранения и обработки информации (в разработке), основанная на ассоциативной модели данных.
 
 ## Требования
@@ -6,7 +6,7 @@
 * [.NET Core](https://www.microsoft.com/net) SDK версии 2.2 или выше.
 * [MonoDevelop](https://www.monodevelop.com/), [Visual Studio](https://visualstudio.microsoft.com) или любая другая [ИСР](https://ru.wikipedia.org/wiki/%D0%98%D0%BD%D1%82%D0%B5%D0%B3%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%B0%D1%8F_%D1%81%D1%80%D0%B5%D0%B4%D0%B0_%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B8) или просто [текстовый редактор](https://ru.wikipedia.org/wiki/%D0%A2%D0%B5%D0%BA%D1%81%D1%82%D0%BE%D0%B2%D1%8B%D0%B9_%D1%80%D0%B5%D0%B4%D0%B0%D0%BA%D1%82%D0%BE%D1%80).
 
-## NuGet пакеты Платформы Связей
+## NuGet пакеты Linkform
 
 ### Основные пакеты
 


### PR DESCRIPTION
## Summary

This PR renames the project from **LinksPlatform** to **Linkform** in the documentation, addressing issue #113.

### Changes Made

- Updated `docfx.json`: Changed `_appTitle` from "LinksPlatform" to "Linkform"
- Updated `index.md`: Changed main title from "Links Platform" to "Linkform" and section header to "Linkform's NuGet packages"
- Updated `index.ru.md`: Changed main title from "Платформа Связей" to "Linkform" and section header to "NuGet пакеты Linkform"

### Rationale

As stated in issue #113, "Platform" implies something flat to base on, while links are not flat - they are unlimited in depth and scale. The name "Linkform" better represents the concept of storing, changing, and using form descriptions in link form.

### Scope

This is a **conservative, non-breaking change** that:
- ✅ Updates the project branding/name in documentation
- ✅ Preserves all code namespaces (`Platform.Data`, `Platform.Data.Doublets`, etc.)
- ✅ Keeps GitHub URLs unchanged (they still point to `konard/LinksPlatform`)
- ✅ Maintains backward compatibility with existing code and packages

### Note

The actual GitHub repository rename would need to be performed separately by a repository administrator. Once the repository is renamed, URLs and additional references can be updated in a follow-up PR.

Fixes #113

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)