### PR TITLE
Implement Each method for Triple Links

### DIFF
--- a/28.03.2010-04.11.2010/Net/Net/Link.cs
+++ b/28.03.2010-04.11.2010/Net/Net/Link.cs
@@ -8,6 +8,9 @@ namespace Net
 {
 	public partial class Link
 	{
+		private static readonly HashSet<Link> AllLinks = new HashSet<Link>();
+		private static readonly object AllLinksLock = new object();
+
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private Link m_Source;
 
@@ -244,6 +247,10 @@ namespace Net
 					Linker = linker,
 					Target = target,
 				};
+				lock (AllLinksLock)
+				{
+					AllLinks.Add(link);
+				}
 			}
 			return link;
 		}
@@ -254,6 +261,10 @@ namespace Net
 			link.Source = link;
 			link.Linker = linker;
 			link.Target = target;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -263,6 +274,10 @@ namespace Net
 			link.Source = link;
 			link.Linker = link;
 			link.Target = target;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -272,6 +287,10 @@ namespace Net
 			link.Source = source;
 			link.Linker = linker;
 			link.Target = link;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -281,6 +300,10 @@ namespace Net
 			link.Source = source;
 			link.Linker = link;
 			link.Target = target;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -290,6 +313,10 @@ namespace Net
 			link.Source = link;
 			link.Linker = linker;
 			link.Target = link;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -299,6 +326,10 @@ namespace Net
 			link.Source = link;
 			link.Linker = link;
 			link.Target = link;
+			lock (AllLinksLock)
+			{
+				AllLinks.Add(link);
+			}
 			return link;
 		}
 
@@ -393,6 +424,80 @@ namespace Net
 			while (m_FirstRefererBySource != null) m_FirstRefererBySource.Delete();
 			while (m_FirstRefererByLinker != null) m_FirstRefererByLinker.Delete();
 			while (m_FirstRefererByTarget != null) m_FirstRefererByTarget.Delete();
+			lock (AllLinksLock)
+			{
+				AllLinks.Remove(this);
+			}
+		}
+
+		/// <summary>
+		/// Iterates through all links matching the specified restriction and invokes the handler for each matching link.
+		/// </summary>
+		/// <param name="source">Source restriction. Null means any source.</param>
+		/// <param name="linker">Linker restriction. Null means any linker.</param>
+		/// <param name="target">Target restriction. Null means any target.</param>
+		/// <param name="handler">Handler function that receives each matching link. Return true to continue iteration, false to break.</param>
+		/// <returns>True if iteration completed without interruption, false if iteration was stopped by handler.</returns>
+		static public bool Each(Link source, Link linker, Link target, Func<Link, bool> handler)
+		{
+			if (handler == null)
+			{
+				return true;
+			}
+
+			lock (AllLinksLock)
+			{
+				foreach (var link in AllLinks)
+				{
+					// Check if link matches the restriction
+					bool matches = true;
+
+					if (source != null && link.Source != source)
+					{
+						matches = false;
+					}
+
+					if (linker != null && link.Linker != linker)
+					{
+						matches = false;
+					}
+
+					if (target != null && link.Target != target)
+					{
+						matches = false;
+					}
+
+					if (matches)
+					{
+						if (!handler(link))
+						{
+							return false; // Handler returned false, stop iteration
+						}
+					}
+				}
+			}
+
+			return true; // Completed iteration
+		}
+
+		/// <summary>
+		/// Iterates through all links and invokes the handler for each link.
+		/// </summary>
+		/// <param name="handler">Handler action that receives each link.</param>
+		static public void Each(Action<Link> handler)
+		{
+			if (handler == null)
+			{
+				return;
+			}
+
+			lock (AllLinksLock)
+			{
+				foreach (var link in AllLinks)
+				{
+					handler(link);
+				}
+			}
 		}
 
 		public override string ToString()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-123-960528c4
+Your prepared working directory: /tmp/gh-issue-solver-1760642495650
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-123-960528c4
-Your prepared working directory: /tmp/gh-issue-solver-1760642495650
-
-Proceed.

--- a/experiments/EachMethodTest.cs
+++ b/experiments/EachMethodTest.cs
@@ -1,0 +1,97 @@
+using System;
+using Net;
+
+namespace Experiments
+{
+	/// <summary>
+	/// Simple test to demonstrate the Each method functionality for Triple Links
+	/// </summary>
+	public class EachMethodTest
+	{
+		public static void Main()
+		{
+			Console.WriteLine("=== Each Method Test for Triple Links ===\n");
+
+			// Create some test links
+			var link1 = Link.CreateLinkLinkingItself();
+			link1.SetName("SelfLink");
+
+			var link2 = Link.CreateCycleSelflink(Net.Net.IsA);
+			link2.SetName("CycleSelfLink");
+
+			var link3 = Link.Create(Net.Net.Thing, Net.Net.IsA, Net.Net.Link);
+			link3.SetName("ThingIsALink");
+
+			Console.WriteLine("Created 3 test links\n");
+
+			// Test 1: Iterate through all links
+			Console.WriteLine("Test 1: Iterate through ALL links");
+			int count = 0;
+			Link.Each(link =>
+			{
+				count++;
+				string name;
+				if (link.TryGetName(out name))
+				{
+					Console.WriteLine($"  Link #{count}: {name}");
+				}
+				else
+				{
+					Console.WriteLine($"  Link #{count}: (unnamed)");
+				}
+			});
+			Console.WriteLine($"Total links found: {count}\n");
+
+			// Test 2: Find links with specific source (Net.Thing)
+			Console.WriteLine("Test 2: Find links where Source = Net.Thing");
+			int specificCount = 0;
+			Link.Each(Net.Net.Thing, null, null, link =>
+			{
+				specificCount++;
+				string name;
+				if (link.TryGetName(out name))
+				{
+					Console.WriteLine($"  Found: {name}");
+				}
+				else
+				{
+					Console.WriteLine($"  Found: (unnamed)");
+				}
+				return true; // Continue iteration
+			});
+			Console.WriteLine($"Links with Source=Net.Thing: {specificCount}\n");
+
+			// Test 3: Find links with specific linker (Net.IsA)
+			Console.WriteLine("Test 3: Find links where Linker = Net.IsA");
+			specificCount = 0;
+			Link.Each(null, Net.Net.IsA, null, link =>
+			{
+				specificCount++;
+				string name;
+				if (link.TryGetName(out name))
+				{
+					Console.WriteLine($"  Found: {name}");
+				}
+				else
+				{
+					Console.WriteLine($"  Found: (unnamed)");
+				}
+				return true;
+			});
+			Console.WriteLine($"Links with Linker=Net.IsA: {specificCount}\n");
+
+			// Test 4: Early termination by returning false
+			Console.WriteLine("Test 4: Early termination (stop after 3 links)");
+			int limitCount = 0;
+			Link.Each(null, null, null, link =>
+			{
+				limitCount++;
+				Console.WriteLine($"  Processing link #{limitCount}");
+				return limitCount < 3; // Stop after 3 links
+			});
+			Console.WriteLine($"Stopped after {limitCount} links\n");
+
+			Console.WriteLine("=== All tests completed successfully ===");
+		}
+	}
+}


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request implements the **Each method for Triple Links** to solve issue #123.

### 📋 Issue Reference
Fixes #123

### 🎯 Implementation Summary

Implemented the `Each` method for the Link class in `28.03.2010-04.11.2010/Net/Net/Link.cs` to enable iteration through all triple links (links with Source, Linker, and Target) with optional filtering capabilities.

### ✨ Key Features

1. **Link Tracking**: Added static `AllLinks` HashSet to maintain a collection of all created links
2. **Thread Safety**: Implemented `AllLinksLock` for safe concurrent access to the links collection
3. **Two Each Method Overloads**:
   - `Each(source, linker, target, handler)` - Iterate with filtering by any combination of source/linker/target (null means "any")
   - `Each(handler)` - Iterate through all links without filtering
4. **Early Termination**: The filtered version supports early termination by returning false from the handler
5. **Lifecycle Management**: Integrated with existing Create* and Delete methods to maintain collection integrity

### 📝 Implementation Details

#### Modified Methods:
- `Create(source, linker, target)` - Now registers created links
- `CreateOutcomingSelflink()` - Now registers created links
- `CreateOutcomingSelflinker()` - Now registers created links
- `CreateIncomingSelflink()` - Now registers created links
- `CreateSelflinker()` - Now registers created links
- `CreateCycleSelflink()` - Now registers created links
- `CreateLinkLinkingItself()` - Now registers created links
- `Delete()` - Now removes deleted links from collection

#### New Methods:
```csharp
// Iterate with filtering
static public bool Each(Link source, Link linker, Link target, Func<Link, bool> handler)

// Iterate all links
static public void Each(Action<Link> handler)
```

### 🧪 Testing

Created test example in `experiments/EachMethodTest.cs` demonstrating:
- Iterating through all links
- Filtering links by specific source
- Filtering links by specific linker
- Early termination of iteration

### 📚 Design Pattern

This implementation follows the same pattern as the `Each` method in [Platform.Data.Doublets](https://github.com/linksplatform/Data.Doublets), maintaining consistency across the LinksPlatform ecosystem.

### 🔍 Usage Examples

```csharp
// Iterate through all links
Link.Each(link => {
    Console.WriteLine($"Link: {link}");
});

// Find all links with specific source
Link.Each(Net.Thing, null, null, link => {
    Console.WriteLine($"Found link with source Net.Thing");
    return true; // Continue iteration
});

// Find links and stop after first match
bool found = false;
Link.Each(null, Net.IsA, null, link => {
    found = true;
    return false; // Stop iteration
});
```

### ✅ Status
**Ready for Review** - Implementation complete with example code demonstrating functionality.

---
*This PR was created automatically by the AI issue solver*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>