### PR TITLE
Add Platform.CachingWebProxy for personal use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-130-41274a8f
+Your prepared working directory: /tmp/gh-issue-solver-1760644365564
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-130-41274a8f
-Your prepared working directory: /tmp/gh-issue-solver-1760644365564
-
-Proceed.

--- a/Platform/Platform.CachingWebProxy/CachedResponse.cs
+++ b/Platform/Platform.CachingWebProxy/CachedResponse.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Platform.CachingWebProxy
+{
+    /// <summary>
+    /// Represents a cached HTTP response with metadata.
+    /// </summary>
+    public class CachedResponse
+    {
+        /// <summary>
+        /// Gets or sets the HTTP status code of the cached response.
+        /// </summary>
+        public int StatusCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response headers.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response body content.
+        /// </summary>
+        public byte[] Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp when this response was cached.
+        /// </summary>
+        public DateTime CachedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content type of the response.
+        /// </summary>
+        public string ContentType { get; set; }
+
+        public CachedResponse()
+        {
+            Headers = new Dictionary<string, string>();
+        }
+    }
+}

--- a/Platform/Platform.CachingWebProxy/CachingProxyServer.cs
+++ b/Platform/Platform.CachingWebProxy/CachingProxyServer.cs
@@ -1,0 +1,266 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Platform.CachingWebProxy
+{
+    /// <summary>
+    /// A caching HTTP proxy server that intercepts requests and caches responses.
+    /// </summary>
+    public class CachingProxyServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly HttpClient _httpClient;
+        private readonly IResponseCache _cache;
+        private readonly string _prefix;
+        private bool _isRunning;
+        private CancellationTokenSource _cancellationTokenSource;
+        private long _totalRequests;
+        private long _cacheHits;
+        private long _cacheMisses;
+
+        /// <summary>
+        /// Gets the total number of requests processed.
+        /// </summary>
+        public long TotalRequests => _totalRequests;
+
+        /// <summary>
+        /// Gets the number of cache hits.
+        /// </summary>
+        public long CacheHits => _cacheHits;
+
+        /// <summary>
+        /// Gets the number of cache misses.
+        /// </summary>
+        public long CacheMisses => _cacheMisses;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachingProxyServer"/> class.
+        /// </summary>
+        /// <param name="prefix">The URL prefix to listen on (e.g., "http://localhost:8080/").</param>
+        /// <param name="cache">The response cache implementation to use.</param>
+        public CachingProxyServer(string prefix, IResponseCache cache = null)
+        {
+            _prefix = prefix;
+            _cache = cache ?? new MemoryResponseCache();
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(_prefix);
+            _httpClient = new HttpClient();
+            _httpClient.Timeout = TimeSpan.FromSeconds(30);
+        }
+
+        /// <summary>
+        /// Starts the proxy server.
+        /// </summary>
+        public void Start()
+        {
+            if (_isRunning)
+            {
+                return;
+            }
+
+            _listener.Start();
+            _isRunning = true;
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            Console.WriteLine($"Caching proxy server started on {_prefix}");
+            Console.WriteLine("Configure your browser to use this proxy.");
+            Console.WriteLine("Press Ctrl+C to stop the server.");
+
+            Task.Run(() => ProcessRequestsAsync(_cancellationTokenSource.Token));
+        }
+
+        /// <summary>
+        /// Stops the proxy server.
+        /// </summary>
+        public void Stop()
+        {
+            if (!_isRunning)
+            {
+                return;
+            }
+
+            _cancellationTokenSource?.Cancel();
+            _listener.Stop();
+            _isRunning = false;
+
+            Console.WriteLine("Proxy server stopped.");
+            PrintStatistics();
+        }
+
+        private async Task ProcessRequestsAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested && _isRunning)
+            {
+                try
+                {
+                    var context = await _listener.GetContextAsync();
+                    _ = Task.Run(() => HandleRequestAsync(context), cancellationToken);
+                }
+                catch (HttpListenerException)
+                {
+                    // Listener was stopped
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error processing request: {ex.Message}");
+                }
+            }
+        }
+
+        private async Task HandleRequestAsync(HttpListenerContext context)
+        {
+            Interlocked.Increment(ref _totalRequests);
+
+            var request = context.Request;
+            var response = context.Response;
+
+            try
+            {
+                // For proxy requests, the URL should be in the request URL
+                var targetUrl = request.Url.ToString();
+
+                // Simple proxy mode: extract target from query parameter or path
+                if (request.QueryString["url"] != null)
+                {
+                    targetUrl = request.QueryString["url"];
+                }
+
+                Console.WriteLine($"[{_totalRequests}] {request.HttpMethod} {targetUrl}");
+
+                // Check cache first
+                if (request.HttpMethod == "GET" && _cache.TryGet(targetUrl, out var cachedResponse))
+                {
+                    Interlocked.Increment(ref _cacheHits);
+                    Console.WriteLine($"  -> Cache HIT");
+                    await WriteResponseAsync(response, cachedResponse);
+                }
+                else
+                {
+                    Interlocked.Increment(ref _cacheMisses);
+                    Console.WriteLine($"  -> Cache MISS, fetching from origin...");
+
+                    // Fetch from origin
+                    var fetchedResponse = await FetchFromOriginAsync(targetUrl, request);
+
+                    // Cache GET requests
+                    if (request.HttpMethod == "GET" && fetchedResponse.StatusCode == 200)
+                    {
+                        _cache.Set(targetUrl, fetchedResponse);
+                    }
+
+                    await WriteResponseAsync(response, fetchedResponse);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  -> Error: {ex.Message}");
+                response.StatusCode = 500;
+                var errorBytes = Encoding.UTF8.GetBytes($"Proxy error: {ex.Message}");
+                response.ContentLength64 = errorBytes.Length;
+                await response.OutputStream.WriteAsync(errorBytes, 0, errorBytes.Length);
+            }
+            finally
+            {
+                response.Close();
+            }
+        }
+
+        private async Task<CachedResponse> FetchFromOriginAsync(string url, HttpListenerRequest originalRequest)
+        {
+            var requestMessage = new HttpRequestMessage(new HttpMethod(originalRequest.HttpMethod), url);
+
+            // Copy headers (except Host and Connection)
+            foreach (var headerName in originalRequest.Headers.AllKeys)
+            {
+                if (headerName.Equals("Host", StringComparison.OrdinalIgnoreCase) ||
+                    headerName.Equals("Connection", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    requestMessage.Headers.TryAddWithoutValidation(headerName, originalRequest.Headers[headerName]);
+                }
+                catch
+                {
+                    // Skip problematic headers
+                }
+            }
+
+            var httpResponse = await _httpClient.SendAsync(requestMessage);
+            var content = await httpResponse.Content.ReadAsByteArrayAsync();
+
+            var cachedResponse = new CachedResponse
+            {
+                StatusCode = (int)httpResponse.StatusCode,
+                Content = content,
+                ContentType = httpResponse.Content.Headers.ContentType?.ToString()
+            };
+
+            // Copy response headers
+            foreach (var header in httpResponse.Headers)
+            {
+                cachedResponse.Headers[header.Key] = string.Join(", ", header.Value);
+            }
+
+            return cachedResponse;
+        }
+
+        private async Task WriteResponseAsync(HttpListenerResponse response, CachedResponse cachedResponse)
+        {
+            response.StatusCode = cachedResponse.StatusCode;
+
+            if (!string.IsNullOrEmpty(cachedResponse.ContentType))
+            {
+                response.ContentType = cachedResponse.ContentType;
+            }
+
+            foreach (var header in cachedResponse.Headers)
+            {
+                try
+                {
+                    response.Headers[header.Key] = header.Value;
+                }
+                catch
+                {
+                    // Skip headers that can't be set
+                }
+            }
+
+            if (cachedResponse.Content != null && cachedResponse.Content.Length > 0)
+            {
+                response.ContentLength64 = cachedResponse.Content.Length;
+                await response.OutputStream.WriteAsync(cachedResponse.Content, 0, cachedResponse.Content.Length);
+            }
+        }
+
+        private void PrintStatistics()
+        {
+            Console.WriteLine("\n=== Proxy Statistics ===");
+            Console.WriteLine($"Total Requests: {TotalRequests}");
+            Console.WriteLine($"Cache Hits: {CacheHits}");
+            Console.WriteLine($"Cache Misses: {CacheMisses}");
+            if (TotalRequests > 0)
+            {
+                var hitRate = (double)CacheHits / TotalRequests * 100;
+                Console.WriteLine($"Cache Hit Rate: {hitRate:F2}%");
+            }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            _httpClient?.Dispose();
+            _listener?.Close();
+            _cancellationTokenSource?.Dispose();
+        }
+    }
+}

--- a/Platform/Platform.CachingWebProxy/IResponseCache.cs
+++ b/Platform/Platform.CachingWebProxy/IResponseCache.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Platform.CachingWebProxy
+{
+    /// <summary>
+    /// Interface for caching HTTP responses.
+    /// </summary>
+    public interface IResponseCache
+    {
+        /// <summary>
+        /// Tries to get a cached response for the specified URL.
+        /// </summary>
+        /// <param name="url">The URL to look up in the cache.</param>
+        /// <param name="response">The cached response if found.</param>
+        /// <returns>True if a cached response was found; otherwise, false.</returns>
+        bool TryGet(string url, out CachedResponse response);
+
+        /// <summary>
+        /// Stores a response in the cache.
+        /// </summary>
+        /// <param name="url">The URL to cache the response for.</param>
+        /// <param name="response">The response to cache.</param>
+        void Set(string url, CachedResponse response);
+
+        /// <summary>
+        /// Removes a cached response for the specified URL.
+        /// </summary>
+        /// <param name="url">The URL to remove from cache.</param>
+        void Remove(string url);
+
+        /// <summary>
+        /// Clears all cached responses.
+        /// </summary>
+        void Clear();
+    }
+}

--- a/Platform/Platform.CachingWebProxy/MemoryResponseCache.cs
+++ b/Platform/Platform.CachingWebProxy/MemoryResponseCache.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Platform.CachingWebProxy
+{
+    /// <summary>
+    /// In-memory implementation of response cache using ConcurrentDictionary.
+    /// </summary>
+    public class MemoryResponseCache : IResponseCache
+    {
+        private readonly ConcurrentDictionary<string, CachedResponse> _cache;
+        private readonly TimeSpan _defaultExpiration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryResponseCache"/> class.
+        /// </summary>
+        /// <param name="defaultExpiration">Default expiration time for cached responses. Defaults to 1 hour.</param>
+        public MemoryResponseCache(TimeSpan? defaultExpiration = null)
+        {
+            _cache = new ConcurrentDictionary<string, CachedResponse>();
+            _defaultExpiration = defaultExpiration ?? TimeSpan.FromHours(1);
+        }
+
+        /// <inheritdoc />
+        public bool TryGet(string url, out CachedResponse response)
+        {
+            if (_cache.TryGetValue(url, out response))
+            {
+                // Check if the cached response has expired
+                if (DateTime.UtcNow - response.CachedAt < _defaultExpiration)
+                {
+                    return true;
+                }
+                else
+                {
+                    // Remove expired entry
+                    _cache.TryRemove(url, out _);
+                    response = null;
+                    return false;
+                }
+            }
+            response = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public void Set(string url, CachedResponse response)
+        {
+            response.CachedAt = DateTime.UtcNow;
+            _cache[url] = response;
+        }
+
+        /// <inheritdoc />
+        public void Remove(string url)
+        {
+            _cache.TryRemove(url, out _);
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            _cache.Clear();
+        }
+
+        /// <summary>
+        /// Gets the current number of cached responses.
+        /// </summary>
+        public int Count => _cache.Count;
+    }
+}

--- a/Platform/Platform.CachingWebProxy/Platform.CachingWebProxy.csproj
+++ b/Platform/Platform.CachingWebProxy/Platform.CachingWebProxy.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Description>LinksPlatform's Platform.CachingWebProxy - A caching HTTP proxy for personal use</Description>
+    <Copyright>Konstantin Diachenko</Copyright>
+    <AssemblyTitle>Platform.CachingWebProxy</AssemblyTitle>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <Authors>Konstantin Diachenko</Authors>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <AssemblyName>Platform.CachingWebProxy</AssemblyName>
+    <PackageId>Platform.CachingWebProxy</PackageId>
+    <PackageTags>LinksPlatform;Proxy;Cache;HTTP</PackageTags>
+    <PackageIconUrl>https://raw.githubusercontent.com/Konard/LinksPlatform/master/doc/Avatar-rainbow.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/Konard/LinksPlatform/tree/master/Platform/Platform.CachingWebProxy</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/Konard/LinksPlatform/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/Konard/LinksPlatform</RepositoryUrl>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/Platform/Platform.CachingWebProxy/Program.cs
+++ b/Platform/Platform.CachingWebProxy/Program.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading;
+
+namespace Platform.CachingWebProxy
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var port = 8080;
+            var cacheExpiration = TimeSpan.FromHours(1);
+
+            // Parse command line arguments
+            for (int i = 0; i < args.Length; i++)
+            {
+                if ((args[i] == "-p" || args[i] == "--port") && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[i + 1], out var parsedPort))
+                    {
+                        port = parsedPort;
+                    }
+                    i++;
+                }
+                else if ((args[i] == "-e" || args[i] == "--expiration") && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[i + 1], out var hours))
+                    {
+                        cacheExpiration = TimeSpan.FromHours(hours);
+                    }
+                    i++;
+                }
+                else if (args[i] == "-h" || args[i] == "--help")
+                {
+                    PrintHelp();
+                    return;
+                }
+            }
+
+            Console.WriteLine("=== LinksPlatform Caching Web Proxy ===");
+            Console.WriteLine($"Cache expiration: {cacheExpiration.TotalHours} hours");
+            Console.WriteLine();
+
+            var cache = new MemoryResponseCache(cacheExpiration);
+            var prefix = $"http://localhost:{port}/";
+
+            using (var server = new CachingProxyServer(prefix, cache))
+            {
+                server.Start();
+
+                // Wait for Ctrl+C
+                var exitEvent = new ManualResetEvent(false);
+                Console.CancelKeyPress += (sender, e) =>
+                {
+                    e.Cancel = true;
+                    exitEvent.Set();
+                };
+
+                exitEvent.WaitOne();
+                Console.WriteLine("\nShutting down...");
+                server.Stop();
+            }
+        }
+
+        static void PrintHelp()
+        {
+            Console.WriteLine("LinksPlatform Caching Web Proxy");
+            Console.WriteLine();
+            Console.WriteLine("Usage: Platform.CachingWebProxy [options]");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  -p, --port <port>           Port to listen on (default: 8080)");
+            Console.WriteLine("  -e, --expiration <hours>    Cache expiration time in hours (default: 1)");
+            Console.WriteLine("  -h, --help                  Show this help message");
+            Console.WriteLine();
+            Console.WriteLine("Example:");
+            Console.WriteLine("  Platform.CachingWebProxy -p 8888 -e 24");
+            Console.WriteLine();
+            Console.WriteLine("To use the proxy, configure your browser or application to use:");
+            Console.WriteLine("  HTTP Proxy: localhost:<port>");
+            Console.WriteLine();
+            Console.WriteLine("Or access URLs directly:");
+            Console.WriteLine("  http://localhost:<port>/?url=<target-url>");
+        }
+    }
+}

--- a/Platform/Platform.sln
+++ b/Platform/Platform.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.MasterServer"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.ConsoleTerminal", "Platform.Data.ConsoleTerminal\Platform.Data.ConsoleTerminal.csproj", "{85D097CE-614E-4351-920B-45BD35AE5A84}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.CachingWebProxy", "Platform.CachingWebProxy\Platform.CachingWebProxy.csproj", "{7F8B1C3D-4E5F-4A6B-9D8E-2F1A3B4C5D6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F8B1C3D-4E5F-4A6B-9D8E-2F1A3B4C5D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F8B1C3D-4E5F-4A6B-9D8E-2F1A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F8B1C3D-4E5F-4A6B-9D8E-2F1A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F8B1C3D-4E5F-4A6B-9D8E-2F1A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Implements a caching HTTP proxy server for personal use, as requested in issue #130. This tool is inspired by FiddlerCore and provides local HTTP request caching to improve browsing speed and reduce bandwidth usage.

## Implementation Details

### Core Components

1. **CachedResponse** - Data model for cached HTTP responses with metadata (status code, headers, content, timestamp)

2. **IResponseCache** - Interface for cache implementations supporting Get/Set/Remove/Clear operations

3. **MemoryResponseCache** - In-memory cache implementation with:
   - Thread-safe concurrent dictionary storage
   - Configurable expiration time (default: 1 hour)
   - Automatic cleanup of expired entries

4. **CachingProxyServer** - Main proxy server featuring:
   - HttpListener-based request handling
   - Asynchronous request processing
   - GET request caching (200 OK responses only)
   - Real-time statistics (cache hits, misses, hit rate)
   - Graceful shutdown with statistics reporting

5. **Program** - CLI application with:
   - Command-line argument parsing (port, cache expiration)
   - Help documentation
   - Signal handling for Ctrl+C

### Features

- ✅ In-memory HTTP response caching
- ✅ Configurable cache expiration time
- ✅ Thread-safe concurrent request handling  
- ✅ Real-time cache performance statistics
- ✅ Simple URL proxy mode via query parameter
- ✅ Command-line configuration options

### Usage

```bash
# Start proxy on port 8080 with 24-hour cache expiration
Platform.CachingWebProxy -p 8080 -e 24

# Access URLs through the proxy
http://localhost:8080/?url=<target-url>
```

### Example Output

```
=== LinksPlatform Caching Web Proxy ===
Cache expiration: 24 hours

Caching proxy server started on http://localhost:8080/
Configure your browser to use this proxy.
Press Ctrl+C to stop the server.

[1] GET http://example.com/api/data
  -> Cache MISS, fetching from origin...
[2] GET http://example.com/api/data
  -> Cache HIT
```

## Testing

- ✅ Project builds successfully in solution
- ✅ All existing projects continue to build
- ✅ Added to Platform.sln with proper configuration

## Related Issue

Fixes #130

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>