### PR TITLE
Add build instructions to root README files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-156-e2209a49
+Your prepared working directory: /tmp/gh-issue-solver-1760648926934
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-156-e2209a49
-Your prepared working directory: /tmp/gh-issue-solver-1760648926934
-
-Proceed.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 # LinksPlatform ([русская версия](https://github.com/Konard/LinksPlatform/blob/master/README.ru.md))
 
 English version of this README page is moved to [our organization's page](https://github.com/linksplatform).
+
+## Build Instructions
+
+To build the project, you can use one of the following methods:
+
+### Visual Studio / MonoDevelop
+
+Open `Platform/Platform.sln` in Visual Studio 2012 (.NET 4.5+) or MonoDevelop and build the solution.
+
+### .NET CLI
+
+```bash
+cd Platform
+dotnet build Platform.sln
+```

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,6 +4,21 @@
 
 Платформа Связей — это [модульный](https://ru.wikipedia.org/wiki/%D0%9C%D0%BE%D0%B4%D1%83%D0%BB%D1%8C%D0%BD%D0%BE%D0%B5_%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5) [фреймворк](https://ru.wikipedia.org/wiki/%D0%A4%D1%80%D0%B5%D0%B9%D0%BC%D0%B2%D0%BE%D1%80%D0%BA), в который входят две [реализации](https://ru.wikipedia.org/wiki/%D0%A0%D0%B5%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F) [СУБД](https://ru.wikipedia.org/wiki/%D0%A1%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D0%B0_%D1%83%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F_%D0%B1%D0%B0%D0%B7%D0%B0%D0%BC%D0%B8_%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85) на основе [ассоциативной модели данных](https://en.wikipedia.org/wiki/Associative_model_of_data): [Дуплеты](https://github.com/linksplatform/Data.Doublets) и [Триплеты](https://github.com/linksplatform/Data.Triplets); а также [трансляторы](https://ru.wikipedia.org/wiki/%D0%A2%D1%80%D0%B0%D0%BD%D1%81%D0%BB%D1%8F%D1%82%D0%BE%D1%80) (например [из C# в C++](https://github.com/linksplatform/RegularExpressions.Transformer.CSharpToCpp)) и [бот](https://github.com/linksplatform/Bot).
 
+## Инструкции по сборке
+
+Для сборки проекта можно использовать один из следующих методов:
+
+### Visual Studio / MonoDevelop
+
+Откройте `Platform/Platform.sln` в Visual Studio 2012 (.NET 4.5+) или MonoDevelop и соберите решение.
+
+### .NET CLI
+
+```bash
+cd Platform
+dotnet build Platform.sln
+```
+
 Каждая из [библиотек](https://ru.wikipedia.org/wiki/%D0%91%D0%B8%D0%B1%D0%BB%D0%B8%D0%BE%D1%82%D0%B5%D0%BA%D0%B0_(%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)) этого [фреймворка](https://ru.wikipedia.org/wiki/%D0%A4%D1%80%D0%B5%D0%B9%D0%BC%D0%B2%D0%BE%D1%80%D0%BA) может быть использована отдельно и располагается [на странице организации "Платформы Связей"](https://github.com/linksplatform).
 
 В данный момент мы используем следующие [языки программирования](https://ru.wikipedia.org/wiki/%D0%AF%D0%B7%D1%8B%D0%BA_%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D1%8F): [C#](https://ru.wikipedia.org/wiki/C_Sharp), [C++](https://ru.wikipedia.org/wiki/C%2B%2B), [C](https://ru.wikipedia.org/wiki/%D0%A1%D0%B8_(%D1%8F%D0%B7%D1%8B%D0%BA_%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D1%8F)), [JavaScript](https://ru.wikipedia.org/wiki/JavaScript) and [Python](https://ru.wikipedia.org/wiki/Python).


### PR DESCRIPTION
## Summary

This pull request adds build instructions to the root README files (both English and Russian versions) as requested in issue #156.

### Changes

- Added "Build Instructions" section to `README.md` with:
  - Instructions for building with Visual Studio 2012 (.NET 4.5+) / MonoDevelop
  - Instructions for building with .NET CLI (`dotnet build`)

- Added "Инструкции по сборке" section to `README.ru.md` with the same content in Russian

### Build Methods Documented

1. **Visual Studio / MonoDevelop**: Open `Platform/Platform.sln` and build the solution
2. **.NET CLI**: Run `dotnet build Platform.sln` from the Platform directory

### Testing

The build instructions were tested locally and confirmed working:
- `dotnet build Platform.sln` successfully builds all projects in the solution
- Build completed with warnings (mainly about outdated .NET Core 2.2 framework) but no errors

### Notes

- The issue mentioned `Platform/Platform.dotnet.sln` but this file does not exist in the repository
- Only `Platform/Platform.sln` exists and works with both Visual Studio and the .NET CLI
- Build instructions are concise and placed early in both README files for easy discovery

Fixes #156

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)