### PR TITLE
Prepare Platform.Examples for NuGet package publishing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-166-4d1e2d6a
-Your prepared working directory: /tmp/gh-issue-solver-1760650657105
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-166-4d1e2d6a
+Your prepared working directory: /tmp/gh-issue-solver-1760650657105
+
+Proceed.

--- a/Platform/Platform.Examples/Platform.Examples.csproj
+++ b/Platform/Platform.Examples/Platform.Examples.csproj
@@ -4,20 +4,23 @@
     <Description>LinksPlatform's Platform.Examples Class Library</Description>
     <Copyright>Konstantin Diachenko</Copyright>
     <AssemblyTitle>Platform.Examples</AssemblyTitle>
-    <VersionPrefix>0.0.1</VersionPrefix>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <Authors>Konstantin Diachenko</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Platform.Examples</AssemblyName>
     <PackageId>Platform.Examples</PackageId>
-    <PackageTags>LinksPlatform;Examples</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/Konard/LinksPlatform/master/doc/Avatar-rainbow.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/Konard/LinksPlatform/tree/master/Platform/Platform.Tests</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Konard/LinksPlatform/master/LICENSE</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>LinksPlatform;Examples;CSVExporter;FileIndexer;GEXFExporter;XMLImporter;ConsoleTerminal;MasterServer;TestsRunner</PackageTags>
+    <PackageIconUrl>https://raw.githubusercontent.com/linksplatform/Documentation/18469f4d033ee9a5b7b84caab9c585acab2ac519/doc/Avatar-rainbow-icon-64x64.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/Konard/LinksPlatform/tree/master/Platform/Platform.Examples</PackageProjectUrl>
+    <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Konard/LinksPlatform</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 📦 Summary

This pull request prepares the **Platform.Examples** library for publication as a NuGet package by updating the project configuration with proper metadata, modern .NET target frameworks, and NuGet best practices.

## 🔗 Issue Reference

Fixes #166

## ✨ Changes Made

### Version & Targeting
- **Bumped version** from `0.0.1` to `0.1.0` for initial release
- **Added multi-targeting support** for broader compatibility:
  - `netstandard2.0` (existing)
  - `netstandard2.1` (added)
  - `net6.0` (added)
  - `net7.0` (added)
  - `net8.0` (added)

### NuGet Package Metadata
- **Fixed PackageProjectUrl**: Changed from incorrect path (`Platform.Tests`) to correct path (`Platform.Examples`)
- **Updated license configuration**: Replaced deprecated `PackageLicenseUrl` with modern `PackageLicenseExpression` set to `Unlicense`
- **Set PackageRequireLicenseAcceptance**: Changed to `false` (appropriate for Unlicense license)
- **Enhanced PackageTags**: Added detailed tags including:
  - `CSVExporter`
  - `FileIndexer`
  - `GEXFExporter`
  - `XMLImporter`
  - `ConsoleTerminal`
  - `MasterServer`
  - `TestsRunner`
- **Updated PackageIconUrl**: Using standard LinksPlatform icon URL

### Build & Documentation
- **Enabled XML documentation generation**: Added `GenerateDocumentationFile=true` for API documentation
- **Explicitly marked as packable**: Added `IsPackable=true` to ensure NuGet package generation
- **Enabled repository URL publishing**: Added `PublishRepositoryUrl=true` for source link support

## 🧪 Testing

- ✅ Local build successful with `dotnet build` (builds for all 5 target frameworks)
- ✅ All CI checks passing
- ✅ No breaking changes to existing functionality
- ✅ XML documentation warnings are expected and can be addressed in future PRs

## 📋 Components Included

The Platform.Examples library contains the following example implementations:
- **CSVExporter** & **CSVSequencesExporter** - Export links data to CSV format
- **FileIndexer** - Index files and their content
- **GEXFExporter** - Export data to GEXF graph format
- **XmlImporter** & **XmlIndexer** - Import and index XML documents
- **XmlElementCounter** - Count XML elements
- **MasterServer** & **TerminalCLI** - Server and terminal examples
- **XUnitTestsRunner** - Test execution utilities

## 🚀 Next Steps

After this PR is merged, the Platform.Examples package will be ready for:
1. Manual publishing to NuGet.org using `dotnet pack` and `dotnet nuget push`
2. Automated publishing via CI/CD pipeline (if configured)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)