### PR TITLE
Remove unused comments from private methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-181-0830f8a7
+Your prepared working directory: /tmp/gh-issue-solver-1760654418687
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-181-0830f8a7
-Your prepared working directory: /tmp/gh-issue-solver-1760654418687
-
-Proceed.

--- a/Platform/Platform.Examples/GEXFExporter.cs
+++ b/Platform/Platform.Examples/GEXFExporter.cs
@@ -63,7 +63,7 @@ namespace Platform.Examples
 
         private string FormatLink(IList<TLink> link)
         {
-            const string format = "{1} {0} {2}"; // "{0}: {1} -> {2}"
+            const string format = "{1} {0} {2}";
             return string.Format(format, link[_links.Constants.IndexPart], link[_links.Constants.SourcePart], link[_links.Constants.TargetPart]);
         }
     }

--- a/Platform/Platform.Examples/MasterServer.cs
+++ b/Platform/Platform.Examples/MasterServer.cs
@@ -38,7 +38,6 @@ namespace Platform.Examples
                 messageHandler("Contents:");
                 var linksTotalLength = _links.Count().ToString("0").Length;
                 var printFormatBase = new string('0', linksTotalLength);
-                // Выделить код по печати одной связи в Extensions
                 var printFormat = string.Format("\t[{{0:{0}}}]: {{1:{0}}} -> {{2:{0}}} {{3}}", printFormatBase);
                 for (var link = UnicodeMap.LastCharLink + 1; link <= _links.Count(); link++)
                 {

--- a/Platform/Platform.Examples/XUnitTestsRunnerCLI.cs
+++ b/Platform/Platform.Examples/XUnitTestsRunnerCLI.cs
@@ -10,11 +10,8 @@ namespace Platform.Examples
     /// </remarks>
     public class XUnitTestsRunnerCLI : ICommandLineInterface
     {
-        // We use consoleLock because messages can arrive in parallel, so we want to make sure we get
-        // consistent console output.
         private readonly object _consoleLock = new object();
 
-        // Use an event to know when we're done
         private readonly ManualResetEvent _finished = new ManualResetEvent(false);
 
         public bool Succeed { get; private set; }

--- a/Platform/Platform.Examples/XmlElementCounter.cs
+++ b/Platform/Platform.Examples/XmlElementCounter.cs
@@ -37,7 +37,7 @@ namespace Platform.Examples
         {
             var rootContext = (RootElementContext)context;
             var parentContexts = new Stack<XmlElementContext>();
-            var elements = new Stack<string>(); // Path
+            var elements = new Stack<string>();
             // TODO: If path was loaded previously, skip it.
             while (reader.Read())
             {
@@ -54,7 +54,7 @@ namespace Platform.Examples
                         if (!reader.IsEmptyElement)
                         {
                             elements.Push(elementName);
-                            ConsoleHelpers.Debug("{0} starting...", elements.Count <= 20 ? ToXPath(elements) : elementName); // XPath
+                            ConsoleHelpers.Debug("{0} starting...", elements.Count <= 20 ? ToXPath(elements) : elementName);
                             parentContexts.Push(context);
                             context = new XmlElementContext();
                         }
@@ -65,9 +65,8 @@ namespace Platform.Examples
                         break;
 
                     case XmlNodeType.EndElement:
-                        ConsoleHelpers.Debug("{0} finished.", elements.Count <= 20 ? ToXPath(elements) : elements.Peek()); // XPath
+                        ConsoleHelpers.Debug("{0} finished.", elements.Count <= 20 ? ToXPath(elements) : elements.Peek());
                         var topElement = elements.Pop();
-                        // Restoring scope
                         context = parentContexts.Pop();
                         if (topElement.StartsWith(elementNameToCount))
                         {

--- a/Platform/Platform.Examples/XmlImporter.cs
+++ b/Platform/Platform.Examples/XmlImporter.cs
@@ -40,7 +40,7 @@ namespace Platform.Examples
         private void Read(XmlReader reader, CancellationToken token, ElementContext context)
         {
             var parentContexts = new Stack<ElementContext>();
-            var elements = new Stack<string>(); // Path
+            var elements = new Stack<string>();
             // TODO: If path was loaded previously, skip it.
             while (reader.Read())
             {
@@ -57,7 +57,7 @@ namespace Platform.Examples
                         if (!reader.IsEmptyElement)
                         {
                             elements.Push(elementName);
-                            ConsoleHelpers.Debug("{0} starting...", elements.Count <= 20 ? ToXPath(elements) : elementName); // XPath
+                            ConsoleHelpers.Debug("{0} starting...", elements.Count <= 20 ? ToXPath(elements) : elementName);
                             var element = _storage.CreateElement(name: elementName);
                             parentContexts.Push(context);
                             _storage.AttachElementToParent(elementToAttach: element, parent: context.Parent);
@@ -69,9 +69,8 @@ namespace Platform.Examples
                         }
                         break;
                     case XmlNodeType.EndElement:
-                        ConsoleHelpers.Debug("{0} finished.", elements.Count <= 20 ? ToXPath(elements) : elements.Peek()); // XPath
+                        ConsoleHelpers.Debug("{0} finished.", elements.Count <= 20 ? ToXPath(elements) : elements.Peek());
                         elements.Pop();
-                        // Restoring scope
                         context = parentContexts.Pop();
                         if (elements.Count == 1)
                         {

--- a/Platform/Platform.Sandbox/ConceptTest.cs
+++ b/Platform/Platform.Sandbox/ConceptTest.cs
@@ -149,7 +149,7 @@ namespace Platform.Sandbox
 
         private static string FormatLink(this UInt64UnitedMemoryLinks links, IList<ulong> link)
         {
-            const string format = "{1} {0} {2}"; // "{0}: {1} -> {2}"
+            const string format = "{1} {0} {2}";
 
             return string.Format(format, link[links.Constants.IndexPart], link[links.Constants.SourcePart], link[links.Constants.TargetPart]);
         }

--- a/Platform/Platform.Sandbox/Zadacha.cs
+++ b/Platform/Platform.Sandbox/Zadacha.cs
@@ -94,7 +94,6 @@ namespace Platform.Sandbox
 
         private static void SetPoints(ILinks<ulong> links, ulong[] digits)
         {
-            // Создадим точки в графе для каждой цифры
             for (int i = 0; i < digits.Length; i++)
             {
                 digits[i] = links.CreatePoint();


### PR DESCRIPTION
## Summary

This PR addresses issue #181 by removing unused comments from private methods and fields while preserving TODO comments and special behavior documentation.

### Changes Made

Removed explanatory comments that don't contain TODO or special behavior notes from:
- **XUnitTestsRunnerCLI.cs**: Removed field explanation comments for `_consoleLock` and `_finished`
- **GEXFExporter.cs**: Removed inline format alternative comment
- **XmlImporter.cs** and **XmlElementCounter.cs**: Removed "Path" comments, "XPath" label comments, and "Restoring scope" comments
- **ConceptTest.cs**: Removed format alternative comment  
- **MasterServer.cs**: Removed refactoring suggestion comment (in Russian)
- **Zadacha.cs**: Removed explanatory comment (in Russian)

### What Was Kept

✅ All TODO comments (algorithm optimization notes, feature requests, bug investigation notes)  
✅ Special behavior documentation in `<remarks>` sections (algorithm references like Byte Pair Encoding)  
✅ Important implementation notes that document special behavior or prevent errors

### Testing

- ✅ Local build successful with `dotnet build` (0 errors, only pre-existing warnings)
- ✅ All CI checks passing

### Files Modified

7 files changed: 8 insertions(+), 15 deletions(-)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #181