### PR TITLE
Swagger specification for Trigger function of IUniLinks interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-190-fd7352a6
-Your prepared working directory: /tmp/gh-issue-solver-1760655905994
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-190-fd7352a6
+Your prepared working directory: /tmp/gh-issue-solver-1760655905994
+
+Proceed.

--- a/trigger-api-swagger.json
+++ b/trigger-api-swagger.json
@@ -1,0 +1,458 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IUniLinks Trigger Function API",
+    "description": "OpenAPI specification for the Trigger function of the IUniLinks interface.\n\nThe IUniLinks interface provides a minimal sufficient universal Links API for bulk and step-by-step operations.\nThe Trigger function is the core operation that allows pattern matching and substitution on links.\n\n## Function Signatures\n\nThe Trigger function has three overloads:\n\n1. **Bulk Operation**: `Trigger(condition, substitution)` - Returns matching and substituted links\n2. **Step-by-Step with Read Handler**: `Trigger(patternOrCondition, matchHandler, substitution, substitutionHandler)` - With callbacks for matched links\n3. **Step-by-Step with Write Handler**: `Trigger(restriction, matchedHandler, substitution, substitutedHandler)` - With callbacks for matched and substituted links\n\n## Use Cases\n\n- **Create**: `{ 0, 0, 0 } => { itself, itself, itself }`\n- **Update**: `{ 1, any, any } => { itself, any, 3 }`\n- **Delete**: `{ 3, any, any } => { 0, 0, 0 }`\n\nBased on the IUniLinks interface from linksplatform/Data repository.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "LinksPlatform",
+      "url": "https://github.com/linksplatform"
+    },
+    "license": {
+      "name": "Unlicense",
+      "url": "https://github.com/linksplatform/Data/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.linksplatform.github.com/v1",
+      "description": "Production server"
+    },
+    {
+      "url": "http://localhost:5000/api/v1",
+      "description": "Development server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Trigger",
+      "description": "Pattern matching and substitution operations on links"
+    }
+  ],
+  "paths": {
+    "/trigger/bulk": {
+      "post": {
+        "tags": ["Trigger"],
+        "summary": "Trigger bulk operation",
+        "description": "Executes a bulk trigger operation that matches links based on a condition and applies substitution.\nReturns a nested list of matched and substituted links.\n\nThis corresponds to the signature:\n`IList<IList<IList<TLinkAddress>?>> Trigger(IList<TLinkAddress>? condition, IList<TLinkAddress>? substitution)`",
+        "operationId": "triggerBulk",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerBulkRequest"
+              },
+              "examples": {
+                "createLink": {
+                  "summary": "Create a new link",
+                  "value": {
+                    "condition": [0, 0, 0],
+                    "substitution": null
+                  }
+                },
+                "updateLink": {
+                  "summary": "Update a link",
+                  "value": {
+                    "condition": [1, null, null],
+                    "substitution": [1, null, 3]
+                  }
+                },
+                "deleteLink": {
+                  "summary": "Delete a link",
+                  "value": {
+                    "condition": [3, null, null],
+                    "substitution": [0, 0, 0]
+                  }
+                },
+                "matchLinks": {
+                  "summary": "Match links with specific source",
+                  "value": {
+                    "condition": [5, null, null],
+                    "substitution": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully executed trigger operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerBulkResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Successful trigger with results",
+                    "value": {
+                      "results": [
+                        [[1, 2, 3], [1, 2, 4]],
+                        [[5, 6, 7], [5, 6, 8]]
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/trigger/step-by-step": {
+      "post": {
+        "tags": ["Trigger"],
+        "summary": "Trigger step-by-step operation with handlers",
+        "description": "Executes a step-by-step trigger operation that matches links based on a pattern/condition\nand applies substitution, calling handlers for matched and substituted links.\n\nReturns a TLinkAddress representing True (fully finished) or False (stopped).\n\nThis corresponds to the signatures:\n- `TLinkAddress Trigger(IList<TLinkAddress>? patternOrCondition, ReadHandler<TLinkAddress>? matchHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutionHandler)`\n- `TLinkAddress Trigger(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? matchedHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutedHandler)`\n\nNote: In HTTP/REST context, handlers are replaced with callback URLs or webhook endpoints.",
+        "operationId": "triggerStepByStep",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerStepByStepRequest"
+              },
+              "examples": {
+                "withCallbacks": {
+                  "summary": "Trigger with callback URLs",
+                  "value": {
+                    "restriction": [1, null, null],
+                    "matchedCallbackUrl": "https://example.com/webhooks/matched",
+                    "substitution": [1, 2, 3],
+                    "substitutedCallbackUrl": "https://example.com/webhooks/substituted"
+                  }
+                },
+                "simpleMatch": {
+                  "summary": "Simple pattern match",
+                  "value": {
+                    "restriction": [5, 6, null],
+                    "substitution": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully executed trigger operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerStepByStepResponse"
+                },
+                "examples": {
+                  "completed": {
+                    "summary": "Operation completed successfully",
+                    "value": {
+                      "result": 1,
+                      "status": "completed"
+                    }
+                  },
+                  "stopped": {
+                    "summary": "Operation stopped",
+                    "value": {
+                      "result": 0,
+                      "status": "stopped"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/trigger/count": {
+      "post": {
+        "tags": ["Trigger"],
+        "summary": "Count links matching restrictions",
+        "description": "Counts the number of links that match the given restrictions.\n\nThis corresponds to the signature:\n`TLinkAddress Count(IList<TLinkAddress>? restrictions)`\n\nThis is a small optimization for common counting operations.",
+        "operationId": "count",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountRequest"
+              },
+              "examples": {
+                "countAll": {
+                  "summary": "Count all links",
+                  "value": {
+                    "restrictions": null
+                  }
+                },
+                "countBySource": {
+                  "summary": "Count links with specific source",
+                  "value": {
+                    "restrictions": [5, null, null]
+                  }
+                },
+                "countBySourceAndLinker": {
+                  "summary": "Count links with source and linker",
+                  "value": {
+                    "restrictions": [5, 6, null]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully counted matching links",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountResponse"
+                },
+                "examples": {
+                  "result": {
+                    "summary": "Count result",
+                    "value": {
+                      "count": 42
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LinkAddress": {
+        "type": "integer",
+        "format": "int64",
+        "description": "A link address (TLinkAddress). Typically a 64-bit unsigned integer.\n- 0 represents null or \"any\" in patterns\n- Positive values represent specific link IDs",
+        "example": 12345
+      },
+      "LinkAddressArray": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": "An array of link addresses, where null represents \"any\" in patterns.\nTypically contains [source, linker, target] for triplets.",
+        "example": [1, 2, 3],
+        "nullable": true
+      },
+      "TriggerBulkRequest": {
+        "type": "object",
+        "properties": {
+          "condition": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            ],
+            "description": "The condition pattern to match against links.\nUse null values for \"any\" matching.\nExamples:\n- [0, 0, 0] for creating new links\n- [1, null, null] for matching links with source=1\n- null for matching all links"
+          },
+          "substitution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            ],
+            "description": "The substitution pattern to apply to matched links.\nUse null to only query without modification.\nExamples:\n- [1, 2, 3] to update matched links to these values\n- [0, 0, 0] to delete matched links\n- null for read-only operations"
+          }
+        }
+      },
+      "TriggerBulkResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            },
+            "description": "A nested list of results: IList<IList<IList<TLinkAddress>>>.\nOuter list: different match groups\nMiddle list: [before, after] pairs for each match\nInner list: [source, linker, target] for each link state",
+            "example": [
+              [[1, 2, 3], [1, 2, 4]],
+              [[5, 6, 7], [5, 6, 8]]
+            ]
+          }
+        }
+      },
+      "TriggerStepByStepRequest": {
+        "type": "object",
+        "properties": {
+          "restriction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            ],
+            "description": "The restriction/pattern/condition to match against links.\nUse null values for \"any\" matching."
+          },
+          "matchedCallbackUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Optional webhook URL to call for each matched link.\nThe callback will receive the matched link as JSON.",
+            "nullable": true,
+            "example": "https://example.com/webhooks/matched"
+          },
+          "substitution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            ],
+            "description": "The substitution pattern to apply to matched links.\nUse null for read-only operations."
+          },
+          "substitutedCallbackUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Optional webhook URL to call for each substituted link.\nThe callback will receive both before and after states as JSON.",
+            "nullable": true,
+            "example": "https://example.com/webhooks/substituted"
+          }
+        }
+      },
+      "TriggerStepByStepResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddress"
+              }
+            ],
+            "description": "Result value representing completion status:\n- Non-zero (typically 1): Operation completed fully (True)\n- Zero (0): Operation was stopped (False)"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["completed", "stopped"],
+            "description": "Human-readable status",
+            "example": "completed"
+          }
+        }
+      },
+      "CountRequest": {
+        "type": "object",
+        "properties": {
+          "restrictions": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddressArray"
+              }
+            ],
+            "description": "Optional restrictions to filter which links to count.\nUse null to count all links.\nUse null values in array for \"any\" matching."
+          }
+        }
+      },
+      "CountResponse": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkAddress"
+              }
+            ],
+            "description": "The number of links matching the restrictions",
+            "example": 42
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Error code",
+            "example": 400
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message",
+            "example": "Invalid condition pattern"
+          },
+          "fields": {
+            "type": "string",
+            "description": "Field name that caused the error (if applicable)",
+            "nullable": true,
+            "example": "condition"
+          }
+        },
+        "required": ["code", "message"]
+      }
+    }
+  }
+}

--- a/trigger-api-swagger.yaml
+++ b/trigger-api-swagger.yaml
@@ -1,0 +1,389 @@
+openapi: 3.0.3
+info:
+  title: IUniLinks Trigger Function API
+  description: |
+    OpenAPI specification for the Trigger function of the IUniLinks interface.
+
+    The IUniLinks interface provides a minimal sufficient universal Links API for bulk and step-by-step operations.
+    The Trigger function is the core operation that allows pattern matching and substitution on links.
+
+    ## Function Signatures
+
+    The Trigger function has three overloads:
+
+    1. **Bulk Operation**: `Trigger(condition, substitution)` - Returns matching and substituted links
+    2. **Step-by-Step with Read Handler**: `Trigger(patternOrCondition, matchHandler, substitution, substitutionHandler)` - With callbacks for matched links
+    3. **Step-by-Step with Write Handler**: `Trigger(restriction, matchedHandler, substitution, substitutedHandler)` - With callbacks for matched and substituted links
+
+    ## Use Cases
+
+    - **Create**: `{ 0, 0, 0 } => { itself, itself, itself }`
+    - **Update**: `{ 1, any, any } => { itself, any, 3 }`
+    - **Delete**: `{ 3, any, any } => { 0, 0, 0 }`
+
+    Based on the IUniLinks interface from linksplatform/Data repository.
+  version: 1.0.0
+  contact:
+    name: LinksPlatform
+    url: https://github.com/linksplatform
+  license:
+    name: Unlicense
+    url: https://github.com/linksplatform/Data/blob/main/LICENSE
+
+servers:
+  - url: https://api.linksplatform.github.com/v1
+    description: Production server
+  - url: http://localhost:5000/api/v1
+    description: Development server
+
+tags:
+  - name: Trigger
+    description: Pattern matching and substitution operations on links
+
+paths:
+  /trigger/bulk:
+    post:
+      tags:
+        - Trigger
+      summary: Trigger bulk operation
+      description: |
+        Executes a bulk trigger operation that matches links based on a condition and applies substitution.
+        Returns a nested list of matched and substituted links.
+
+        This corresponds to the signature:
+        `IList<IList<IList<TLinkAddress>?>> Trigger(IList<TLinkAddress>? condition, IList<TLinkAddress>? substitution)`
+      operationId: triggerBulk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerBulkRequest'
+            examples:
+              createLink:
+                summary: Create a new link
+                value:
+                  condition: [0, 0, 0]
+                  substitution: null
+              updateLink:
+                summary: Update a link
+                value:
+                  condition: [1, null, null]
+                  substitution: [1, null, 3]
+              deleteLink:
+                summary: Delete a link
+                value:
+                  condition: [3, null, null]
+                  substitution: [0, 0, 0]
+              matchLinks:
+                summary: Match links with specific source
+                value:
+                  condition: [5, null, null]
+                  substitution: null
+      responses:
+        '200':
+          description: Successfully executed trigger operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerBulkResponse'
+              examples:
+                success:
+                  summary: Successful trigger with results
+                  value:
+                    results: [
+                      [[1, 2, 3], [1, 2, 4]],
+                      [[5, 6, 7], [5, 6, 8]]
+                    ]
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /trigger/step-by-step:
+    post:
+      tags:
+        - Trigger
+      summary: Trigger step-by-step operation with handlers
+      description: |
+        Executes a step-by-step trigger operation that matches links based on a pattern/condition
+        and applies substitution, calling handlers for matched and substituted links.
+
+        Returns a TLinkAddress representing True (fully finished) or False (stopped).
+
+        This corresponds to the signatures:
+        - `TLinkAddress Trigger(IList<TLinkAddress>? patternOrCondition, ReadHandler<TLinkAddress>? matchHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutionHandler)`
+        - `TLinkAddress Trigger(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? matchedHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutedHandler)`
+
+        Note: In HTTP/REST context, handlers are replaced with callback URLs or webhook endpoints.
+      operationId: triggerStepByStep
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerStepByStepRequest'
+            examples:
+              withCallbacks:
+                summary: Trigger with callback URLs
+                value:
+                  restriction: [1, null, null]
+                  matchedCallbackUrl: "https://example.com/webhooks/matched"
+                  substitution: [1, 2, 3]
+                  substitutedCallbackUrl: "https://example.com/webhooks/substituted"
+              simpleMatch:
+                summary: Simple pattern match
+                value:
+                  restriction: [5, 6, null]
+                  substitution: null
+      responses:
+        '200':
+          description: Successfully executed trigger operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TriggerStepByStepResponse'
+              examples:
+                completed:
+                  summary: Operation completed successfully
+                  value:
+                    result: 1
+                    status: "completed"
+                stopped:
+                  summary: Operation stopped
+                  value:
+                    result: 0
+                    status: "stopped"
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /trigger/count:
+    post:
+      tags:
+        - Trigger
+      summary: Count links matching restrictions
+      description: |
+        Counts the number of links that match the given restrictions.
+
+        This corresponds to the signature:
+        `TLinkAddress Count(IList<TLinkAddress>? restrictions)`
+
+        This is a small optimization for common counting operations.
+      operationId: count
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CountRequest'
+            examples:
+              countAll:
+                summary: Count all links
+                value:
+                  restrictions: null
+              countBySource:
+                summary: Count links with specific source
+                value:
+                  restrictions: [5, null, null]
+              countBySourceAndLinker:
+                summary: Count links with source and linker
+                value:
+                  restrictions: [5, 6, null]
+      responses:
+        '200':
+          description: Successfully counted matching links
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountResponse'
+              examples:
+                result:
+                  summary: Count result
+                  value:
+                    count: 42
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    LinkAddress:
+      type: integer
+      format: int64
+      description: |
+        A link address (TLinkAddress). Typically a 64-bit unsigned integer.
+        - 0 represents null or "any" in patterns
+        - Positive values represent specific link IDs
+      example: 12345
+
+    LinkAddressArray:
+      type: array
+      items:
+        oneOf:
+          - type: integer
+            format: int64
+          - type: "null"
+      description: |
+        An array of link addresses, where null represents "any" in patterns.
+        Typically contains [source, linker, target] for triplets.
+      example: [1, 2, 3]
+      nullable: true
+
+    TriggerBulkRequest:
+      type: object
+      properties:
+        condition:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            The condition pattern to match against links.
+            Use null values for "any" matching.
+            Examples:
+            - [0, 0, 0] for creating new links
+            - [1, null, null] for matching links with source=1
+            - null for matching all links
+        substitution:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            The substitution pattern to apply to matched links.
+            Use null to only query without modification.
+            Examples:
+            - [1, 2, 3] to update matched links to these values
+            - [0, 0, 0] to delete matched links
+            - null for read-only operations
+
+    TriggerBulkResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            A nested list of results: IList<IList<IList<TLinkAddress>>>.
+            Outer list: different match groups
+            Middle list: [before, after] pairs for each match
+            Inner list: [source, linker, target] for each link state
+          example: [
+            [[1, 2, 3], [1, 2, 4]],
+            [[5, 6, 7], [5, 6, 8]]
+          ]
+
+    TriggerStepByStepRequest:
+      type: object
+      properties:
+        restriction:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            The restriction/pattern/condition to match against links.
+            Use null values for "any" matching.
+        matchedCallbackUrl:
+          type: string
+          format: uri
+          description: |
+            Optional webhook URL to call for each matched link.
+            The callback will receive the matched link as JSON.
+          nullable: true
+          example: "https://example.com/webhooks/matched"
+        substitution:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            The substitution pattern to apply to matched links.
+            Use null for read-only operations.
+        substitutedCallbackUrl:
+          type: string
+          format: uri
+          description: |
+            Optional webhook URL to call for each substituted link.
+            The callback will receive both before and after states as JSON.
+          nullable: true
+          example: "https://example.com/webhooks/substituted"
+
+    TriggerStepByStepResponse:
+      type: object
+      properties:
+        result:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddress'
+          description: |
+            Result value representing completion status:
+            - Non-zero (typically 1): Operation completed fully (True)
+            - Zero (0): Operation was stopped (False)
+        status:
+          type: string
+          enum: [completed, stopped]
+          description: Human-readable status
+          example: "completed"
+
+    CountRequest:
+      type: object
+      properties:
+        restrictions:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddressArray'
+          description: |
+            Optional restrictions to filter which links to count.
+            Use null to count all links.
+            Use null values in array for "any" matching.
+
+    CountResponse:
+      type: object
+      properties:
+        count:
+          allOf:
+            - $ref: '#/components/schemas/LinkAddress'
+          description: The number of links matching the restrictions
+          example: 42
+
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Error code
+          example: 400
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Invalid condition pattern"
+        fields:
+          type: string
+          description: Field name that caused the error (if applicable)
+          nullable: true
+          example: "condition"
+      required:
+        - code
+        - message


### PR DESCRIPTION
## 🎯 Summary

This PR provides comprehensive OpenAPI/Swagger specification for the **Trigger** function of the **IUniLinks** interface, addressing issue #190.

## 📋 Issue Reference

Fixes #190  
Related to #49 (WebSocket Terminal / REST API)

## ✨ What's Included

### OpenAPI 3.0.3 Specifications

Two specification files are provided in both YAML and JSON formats:
- `trigger-api-swagger.yaml` - Human-readable YAML format
- `trigger-api-swagger.json` - Machine-readable JSON format

### API Endpoints Documented

#### 1. **POST /trigger/bulk**
Bulk trigger operation for pattern matching and substitution.

**Signature:** `IList<IList<IList<TLinkAddress>?>> Trigger(IList<TLinkAddress>? condition, IList<TLinkAddress>? substitution)`

**Use Cases:**
- Create: `{ 0, 0, 0 } => { itself, itself, itself }`
- Update: `{ 1, any, any } => { itself, any, 3 }`  
- Delete: `{ 3, any, any } => { 0, 0, 0 }`
- Query: Match links with specific patterns

**Returns:** Nested list of matched and substituted links

#### 2. **POST /trigger/step-by-step**
Step-by-step trigger operation with handler callbacks.

**Signatures:**
- `TLinkAddress Trigger(IList<TLinkAddress>? patternOrCondition, ReadHandler<TLinkAddress>? matchHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutionHandler)`
- `TLinkAddress Trigger(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? matchedHandler, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? substitutedHandler)`

**Features:**
- Pattern matching with optional match handlers
- Substitution with optional substitution handlers
- In REST API context, handlers are replaced with webhook callback URLs
- Returns status: True (completed) or False (stopped)

#### 3. **POST /trigger/count**
Optimized count operation for matching links.

**Signature:** `TLinkAddress Count(IList<TLinkAddress>? restrictions)`

**Purpose:** Simple optimization for counting links matching given restrictions

### Complete Schema Definitions

- **LinkAddress** - 64-bit link identifier
- **LinkAddressArray** - Array of link addresses with null for "any" matching
- **TriggerBulkRequest/Response** - Bulk operation models
- **TriggerStepByStepRequest/Response** - Step-by-step operation models
- **CountRequest/Response** - Count operation models
- **Error** - Standard error response

### Documentation Features

- Detailed descriptions for all endpoints and schemas
- Multiple examples for each operation
- HTTP status codes (200, 400, 500) with appropriate responses
- Pattern matching syntax documentation
- Use case examples (create, read, update, delete)

## 🏗️ Technical Details

### Source Interface

The specification is based on the **IUniLinks** interface from the [linksplatform/Data](https://github.com/linksplatform/Data) repository:
- Interface: `csharp/Platform.Data/Universal/IUniLinks.cs`
- Delegates: `ReadHandler<TLinkAddress>` and `WriteHandler<TLinkAddress>` from Platform.Delegates

### Key Design Decisions

1. **OpenAPI 3.0.3**: Modern specification format with full JSON Schema support
2. **REST Adaptation**: Delegate handlers mapped to webhook callback URLs for HTTP/REST context
3. **Pattern Matching**: `null` values represent "any" in restriction patterns
4. **Flexible Operations**: Support for both bulk and step-by-step processing
5. **Examples**: Comprehensive examples for all common operations

### API Structure

```
/api/v1/trigger/
  ├── bulk              - Bulk operations
  ├── step-by-step      - Step-by-step with handlers
  └── count             - Optimized counting
```

## 📖 Usage Examples

### Create a Link
```bash
curl -X POST https://api.linksplatform.github.com/v1/trigger/bulk \
  -H "Content-Type: application/json" \
  -d '{"condition": [0, 0, 0], "substitution": null}'
```

### Update Links
```bash
curl -X POST https://api.linksplatform.github.com/v1/trigger/bulk \
  -H "Content-Type: application/json" \
  -d '{"condition": [1, null, null], "substitution": [1, 2, 3]}'
```

### Count Links
```bash
curl -X POST https://api.linksplatform.github.com/v1/trigger/count \
  -H "Content-Type: application/json" \
  -d '{"restrictions": [5, null, null]}'
```

### Trigger with Webhooks
```bash
curl -X POST https://api.linksplatform.github.com/v1/trigger/step-by-step \
  -H "Content-Type: application/json" \
  -d '{
    "restriction": [1, null, null],
    "matchedCallbackUrl": "https://example.com/webhooks/matched",
    "substitution": [1, 2, 3],
    "substitutedCallbackUrl": "https://example.com/webhooks/substituted"
  }'
```

## 🧪 Validation

The specifications can be validated and visualized using:
- **Swagger Editor**: https://editor.swagger.io/
- **Swagger UI**: For interactive API documentation
- **OpenAPI Validators**: Various tools supporting OpenAPI 3.0.3

To test the specification:
1. Visit https://editor.swagger.io/
2. Import either `trigger-api-swagger.yaml` or `trigger-api-swagger.json`
3. View the rendered documentation and test examples

## 🔗 Related Work

This specification complements:
- **PR #750**: Swagger API Implementation Generator  
- **PR #734**: WebSocket Terminal / REST API implementation
- **Existing Gists**: 
  - [Links (triplets) API](https://gist.github.com/Konard/e6a0bff583bbca4d452b)
  - [Links (doublets) API](https://gist.github.com/Konard/c76f9948bb25a0d7aff1)

## 📝 Notes

- The specification focuses on the IUniLinks interface, which provides the minimal sufficient universal Links API
- Handler delegates (ReadHandler, WriteHandler) are adapted to REST context using webhook callbacks
- Pattern matching uses `null` values to represent "any" in restriction patterns
- The API supports both read-only queries and write operations (create/update/delete)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)