### PR TITLE
Universal Links String file format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-194-0b5c72b3
-Your prepared working directory: /tmp/gh-issue-solver-1760656019298
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-194-0b5c72b3
+Your prepared working directory: /tmp/gh-issue-solver-1760656019298
+
+Proceed.

--- a/Platform/Platform.Examples/UniversalLinksStringFormatExporter.cs
+++ b/Platform/Platform.Examples/UniversalLinksStringFormatExporter.cs
@@ -1,0 +1,127 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Unicode;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Exports links in Universal Links String Format.
+    /// Uses two base symbols: space (link part separator) and newline (link separator).
+    /// This format can represent pair links, triple links, and sequences of any size.
+    /// </summary>
+    /// <remarks>
+    /// Format specification:
+    /// - Space character (' ') separates parts within a link (source and target)
+    /// - Newline character ('\n') separates different links
+    ///
+    /// Example:
+    /// 1 2
+    /// 2 3
+    /// 3 1
+    ///
+    /// This represents three links: (1→2), (2→3), (3→1)
+    ///
+    /// The format is scalable:
+    /// - For pair links (doublets): "source target"
+    /// - For sequences: links can reference other links, building complex structures
+    /// - Can be scaled down to Unicode-like single reference sequences
+    /// </remarks>
+    public class UniversalLinksStringFormatExporter
+    {
+        protected SynchronizedLinks<ulong> _links;
+        protected bool _unicodeMapped;
+        protected bool _convertUnicodeLinksToCharacters;
+        protected bool _referenceByLines;
+        protected HashSet<ulong> _visited;
+        protected Dictionary<ulong, ulong> _addressToLineNumber = new Dictionary<ulong, ulong>();
+        protected ulong _linksCounter;
+        protected ulong _linesCounter;
+
+        /// <summary>
+        /// Exports links to Universal Links String Format.
+        /// </summary>
+        /// <param name="links">The links store to export from.</param>
+        /// <param name="path">The file path to export to.</param>
+        /// <param name="unicodeMapped">Whether Unicode characters are mapped to links.</param>
+        /// <param name="convertUnicodeLinksToCharacters">Whether to convert Unicode link indices to their character representations.</param>
+        /// <param name="referenceByLines">Whether to reference links by their line numbers instead of addresses.</param>
+        /// <param name="cancellationToken">Cancellation token for the export operation.</param>
+        public void Export(SynchronizedLinks<ulong> links, string path, bool unicodeMapped, bool convertUnicodeLinksToCharacters, bool referenceByLines, CancellationToken cancellationToken)
+        {
+            _links = links;
+            _unicodeMapped = unicodeMapped;
+            _convertUnicodeLinksToCharacters = convertUnicodeLinksToCharacters;
+            _referenceByLines = referenceByLines;
+            _visited = new HashSet<ulong>();
+            using (var file = File.OpenWrite(path))
+            using (var writer = new StreamWriter(file, Encoding.UTF8))
+            {
+                _linksCounter = 1;
+                _linesCounter = 0;
+                _links.Each(link =>
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return _links.Constants.Break;
+                    }
+                    var linkIndex = link[_links.Constants.IndexPart];
+                    if (!_unicodeMapped || _linksCounter > UnicodeMap.MapSize)
+                    {
+                        if (Visit(linkIndex))
+                        {
+                            WriteLink(writer, link);
+                        }
+                    }
+                    _linksCounter++;
+                    return _links.Constants.Continue;
+                });
+            }
+        }
+
+        protected bool Visit(ulong linkIndex)
+        {
+            var result = _visited.Add(linkIndex);
+            if (result)
+            {
+                _addressToLineNumber.Add(linkIndex, _linesCounter + 1);
+            }
+            return result;
+        }
+
+        protected virtual void WriteLink(StreamWriter writer, IList<ulong> link)
+        {
+            // Universal Links String Format: "source target\n"
+            // Space is the link part separator, newline is the link separator
+            writer.Write(FormatLink(link[_links.Constants.SourcePart]));
+            writer.Write(' '); // Link part separator
+            writer.WriteLine(FormatLink(link[_links.Constants.TargetPart]));
+            _linesCounter++;
+        }
+
+        protected string FormatLink(ulong link)
+        {
+            if (_unicodeMapped && _convertUnicodeLinksToCharacters && link <= UnicodeMap.MapSize)
+            {
+                var character = UnicodeMap.FromLinkToChar(link);
+                // For special characters that might interfere with format, use link index
+                if (character == ' ' || character == '\n' || character == '\r')
+                {
+                    if (_referenceByLines)
+                    {
+                        link = _addressToLineNumber[link];
+                    }
+                    return link.ToString();
+                }
+                return character.ToString();
+            }
+            if (_referenceByLines)
+            {
+                link = _addressToLineNumber[link];
+            }
+            return link.ToString();
+        }
+    }
+}

--- a/Platform/Platform.Examples/UniversalLinksStringFormatExporterCLI.cs
+++ b/Platform/Platform.Examples/UniversalLinksStringFormatExporterCLI.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using Platform.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Specific;
+using Platform.Data.Doublets.Decorators;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Command-line interface for exporting links to Universal Links String Format.
+    /// </summary>
+    public class UniversalLinksStringFormatExporterCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            var i = 0;
+            var linksFile = ConsoleHelpers.GetOrReadArgument(i++, "Links file", args);
+            var exportTo = ConsoleHelpers.GetOrReadArgument(i++, "Export to", args);
+            var unicodeMapped = ConsoleHelpers.GetOrReadArgument(i++, "Unicode is mapped", args);
+            var convertUnicodeLinksToCharacters = ConsoleHelpers.GetOrReadArgument(i++, "Convert each unicode-link to a corresponding character", args);
+            var referenceByLines = ConsoleHelpers.GetOrReadArgument(i++, "Reference by row (line) number", args);
+            bool.TryParse(unicodeMapped, out bool isUnicodeMapped);
+            bool.TryParse(convertUnicodeLinksToCharacters, out bool doConvertUnicodeLinksToCharacters);
+            bool.TryParse(referenceByLines, out bool doReferenceByLines);
+            File.Create(exportTo).Dispose();
+            if (!File.Exists(linksFile))
+            {
+                Console.WriteLine("Entered links file does not exists.");
+            }
+            else if (!File.Exists(exportTo))
+            {
+                Console.WriteLine("Entered exported file cannot be created.");
+            }
+            else
+            {
+                using (var cancellation = new ConsoleCancellation())
+                using (var memoryAdapter = new UInt64UnitedMemoryLinks(linksFile))
+                using (var links = new UInt64Links(memoryAdapter))
+                {
+                    Console.WriteLine("Press CTRL+C to stop.");
+                    var syncLinks = new SynchronizedLinks<ulong>(links);
+                    var exporter = new UniversalLinksStringFormatExporter();
+                    exporter.Export(syncLinks, exportTo, isUnicodeMapped, doConvertUnicodeLinksToCharacters, doReferenceByLines, cancellation.Token);
+                    Console.WriteLine($"Export completed. File saved to: {exportTo}");
+                }
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/UniversalLinksStringFormatImporter.cs
+++ b/Platform/Platform.Examples/UniversalLinksStringFormatImporter.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Imports links from Universal Links String Format.
+    /// Uses two base symbols: space (link part separator) and newline (link separator).
+    /// This format can represent pair links, triple links, and sequences of any size.
+    /// </summary>
+    /// <remarks>
+    /// Format specification:
+    /// - Space character (' ') separates parts within a link (source and target)
+    /// - Newline character ('\n') separates different links
+    ///
+    /// Example input:
+    /// 1 2
+    /// 2 3
+    /// 3 1
+    ///
+    /// This creates or updates three links: (1→2), (2→3), (3→1)
+    /// </remarks>
+    public class UniversalLinksStringFormatImporter
+    {
+        private readonly SynchronizedLinks<ulong> _links;
+        private readonly bool _useLineNumbersAsIndices;
+        private readonly Dictionary<ulong, ulong> _lineNumberToAddress = new Dictionary<ulong, ulong>();
+
+        /// <summary>
+        /// Creates a new Universal Links String Format importer.
+        /// </summary>
+        /// <param name="links">The links store to import into.</param>
+        /// <param name="useLineNumbersAsIndices">Whether the format uses line numbers as link references.</param>
+        public UniversalLinksStringFormatImporter(SynchronizedLinks<ulong> links, bool useLineNumbersAsIndices = false)
+        {
+            _links = links;
+            _useLineNumbersAsIndices = useLineNumbersAsIndices;
+        }
+
+        /// <summary>
+        /// Imports links from a file in Universal Links String Format.
+        /// </summary>
+        /// <param name="path">The file path to import from.</param>
+        /// <param name="cancellationToken">Cancellation token for the import operation.</param>
+        public void Import(string path, CancellationToken cancellationToken)
+        {
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"File not found: {path}");
+            }
+
+            using (var file = File.OpenRead(path))
+            using (var reader = new StreamReader(file))
+            {
+                ulong lineNumber = 0;
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    lineNumber++;
+
+                    // Skip empty lines
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    // Parse the line: "source target"
+                    var parts = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length != 2)
+                    {
+                        throw new FormatException($"Invalid format at line {lineNumber}: expected 'source target', got '{line}'");
+                    }
+
+                    if (!ulong.TryParse(parts[0], out ulong source))
+                    {
+                        throw new FormatException($"Invalid source value at line {lineNumber}: '{parts[0]}'");
+                    }
+
+                    if (!ulong.TryParse(parts[1], out ulong target))
+                    {
+                        throw new FormatException($"Invalid target value at line {lineNumber}: '{parts[1]}'");
+                    }
+
+                    // Convert line numbers to actual addresses if needed
+                    if (_useLineNumbersAsIndices)
+                    {
+                        if (_lineNumberToAddress.TryGetValue(source, out ulong sourceAddress))
+                        {
+                            source = sourceAddress;
+                        }
+                        if (_lineNumberToAddress.TryGetValue(target, out ulong targetAddress))
+                        {
+                            target = targetAddress;
+                        }
+                    }
+
+                    // Create or update the link
+                    var linkAddress = _links.GetOrCreate(source, target);
+
+                    // Store line number mapping if needed
+                    if (_useLineNumbersAsIndices)
+                    {
+                        _lineNumberToAddress[lineNumber] = linkAddress;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/UniversalLinksStringFormatImporterCLI.cs
+++ b/Platform/Platform.Examples/UniversalLinksStringFormatImporterCLI.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using Platform.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Specific;
+using Platform.Data.Doublets.Decorators;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Command-line interface for importing links from Universal Links String Format.
+    /// </summary>
+    public class UniversalLinksStringFormatImporterCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            var i = 0;
+            var linksFile = ConsoleHelpers.GetOrReadArgument(i++, "Links file (will be created or updated)", args);
+            var importFrom = ConsoleHelpers.GetOrReadArgument(i++, "Import from", args);
+            var useLineNumbers = ConsoleHelpers.GetOrReadArgument(i++, "Use line numbers as link references", args);
+            bool.TryParse(useLineNumbers, out bool doUseLineNumbers);
+
+            if (!File.Exists(importFrom))
+            {
+                Console.WriteLine("Entered import file does not exist.");
+            }
+            else
+            {
+                using (var cancellation = new ConsoleCancellation())
+                using (var memoryAdapter = new UInt64UnitedMemoryLinks(linksFile))
+                using (var links = new UInt64Links(memoryAdapter))
+                {
+                    Console.WriteLine("Press CTRL+C to stop.");
+                    var syncLinks = new SynchronizedLinks<ulong>(links);
+                    var importer = new UniversalLinksStringFormatImporter(syncLinks, doUseLineNumbers);
+                    try
+                    {
+                        importer.Import(importFrom, cancellation.Token);
+                        Console.WriteLine($"Import completed successfully. Links stored in: {linksFile}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Error during import: {ex.Message}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/experiments/universal-links-format/README.md
+++ b/experiments/universal-links-format/README.md
@@ -1,0 +1,153 @@
+# Universal Links String Format
+
+## Overview
+
+The Universal Links String Format is a simple, human-readable file format for storing and transferring links of any size. It uses two base symbols to represent link structures:
+
+1. **Link Part Separator**: Space character (` `)
+2. **Link Separator**: Newline character (`\n`)
+
+This format can represent:
+- Pair links (doublets)
+- Triple links (through composition)
+- Sequences of any size
+- Can be scaled down to Unicode-like single reference sequences
+
+## Format Specification
+
+Each line in the file represents one link with the following structure:
+
+```
+source target
+```
+
+Where:
+- `source` and `target` are numeric identifiers (link addresses or indices)
+- Space (` `) separates the source from the target
+- Newline (`\n`) separates one link from another
+
+## Examples
+
+### Example 1: Simple Pair Links
+
+```
+1 2
+2 3
+3 1
+```
+
+This represents three links:
+- Link at index/address 1: source=1, target=2
+- Link at index/address 2: source=2, target=3
+- Link at index/address 3: source=3, target=1
+
+### Example 2: Building Sequences
+
+Links can reference other links to build complex structures:
+
+```
+65 66
+67 68
+1 2
+```
+
+Here:
+- Link 1 connects 65→66 (could represent "AB" if 65='A', 66='B')
+- Link 2 connects 67→68 (could represent "CD" if 67='C', 68='D')
+- Link 3 connects link 1→link 2 (creates sequence "ABCD")
+
+### Example 3: Unicode-like Representation
+
+When characters are mapped to link indices (Unicode mapping):
+
+```
+72 101
+101 108
+108 108
+108 111
+```
+
+Could represent "Hello" where:
+- 72 = 'H'
+- 101 = 'e'
+- 108 = 'l'
+- 111 = 'o'
+
+## Advantages
+
+1. **Simplicity**: Only two special characters needed
+2. **Human-readable**: Easy to view and edit with any text editor
+3. **Universal**: Works for any link size and structure
+4. **Scalable**: From simple pairs to complex nested structures
+5. **Compatible**: Similar to Unicode but extended to multi-dimensional structures
+6. **Efficient**: Compact representation without heavy markup
+
+## Implementation
+
+The format is implemented in Platform.Examples with:
+
+- `UniversalLinksStringFormatExporter` - Export links to the format
+- `UniversalLinksStringFormatImporter` - Import links from the format
+- `UniversalLinksStringFormatExporterCLI` - Command-line exporter
+- `UniversalLinksStringFormatImporterCLI` - Command-line importer
+
+## Usage
+
+### Exporting Links
+
+```csharp
+var exporter = new UniversalLinksStringFormatExporter();
+exporter.Export(
+    links: syncLinks,
+    path: "output.links",
+    unicodeMapped: true,
+    convertUnicodeLinksToCharacters: false,
+    referenceByLines: false,
+    cancellationToken: cancellationToken
+);
+```
+
+### Importing Links
+
+```csharp
+var importer = new UniversalLinksStringFormatImporter(
+    links: syncLinks,
+    useLineNumbersAsIndices: false
+);
+importer.Import("input.links", cancellationToken);
+```
+
+## Comparison with Other Formats
+
+### vs CSV
+- **CSV**: Requires escaping for commas and quotes, more complex parsing
+- **Universal Links Format**: Only two simple separators, no escaping needed for most cases
+
+### vs JSON/XML
+- **JSON/XML**: Heavy markup, harder to read, larger file size
+- **Universal Links Format**: Minimal markup, easy to read, compact
+
+### vs Binary Protocols
+- **Binary**: Not human-readable, requires special tools
+- **Universal Links Format**: Human-readable, editable with any text editor
+
+## Relation to Links Theory
+
+This format aligns with the Links Platform theory where:
+- Everything is represented as links (associations)
+- Links can reference other links
+- Complex structures emerge from simple binary relationships
+
+The format provides a textual representation that mirrors the internal doublet structure, making it ideal for:
+- Data interchange
+- Debugging and inspection
+- Human-readable storage
+- Cross-platform compatibility
+
+## Future Extensions
+
+Possible extensions while maintaining backward compatibility:
+- Support for link metadata (through special marker links)
+- Compression using reference counting
+- Unicode character literals for mapped links
+- Comments (lines starting with `#`)


### PR DESCRIPTION
## Summary

Implements a **Universal Links String Format** for storing and transferring links of any size, addressing issue #194.

This format uses two base symbols:
- **Space (` `)** - link part separator (separates source and target within a link)
- **Newline (`\n`)** - link separator (separates different links)

### Format Example

```
1 2
2 3
3 1
```

Each line represents a link with format: `source target`

## Implementation

The solution includes:

- **UniversalLinksStringFormatExporter** - Exports links from memory to the string format
- **UniversalLinksStringFormatImporter** - Imports links from the string format into memory
- **UniversalLinksStringFormatExporterCLI** - Command-line interface for exporting
- **UniversalLinksStringFormatImporterCLI** - Command-line interface for importing
- **Comprehensive documentation** - Detailed README with examples, usage, and comparison with other formats

## Features

✅ **Simple & Universal**: Only two special characters needed  
✅ **Human-readable**: Easy to view and edit with any text editor  
✅ **Scalable**: Works for pair links, triple links (through composition), and sequences of any size  
✅ **Compatible**: Similar to Unicode but extended to multi-dimensional structures  
✅ **Efficient**: Compact representation without heavy markup like JSON/XML  
✅ **No escaping needed**: Unlike CSV which requires escaping for commas and quotes  

## Technical Details

- Supports Unicode character mapping for links
- Can reference links by line numbers or addresses
- Handles complex nested structures through link composition
- Maintains compatibility with existing Platform.Examples patterns

## Documentation

Full specification and examples available in: `experiments/universal-links-format/README.md`

## Related Issues

- Fixes #194
- Related to #29 (Links data structure as binary data protocol)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)