### PR TITLE
Add object extensions and context system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-221-82cdd1c2
+Your prepared working directory: /tmp/gh-issue-solver-1760664027109
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-221-82cdd1c2
-Your prepared working directory: /tmp/gh-issue-solver-1760664027109
-
-Proceed.

--- a/Platform/Platform.Examples/ExecutionContext.cs
+++ b/Platform/Platform.Examples/ExecutionContext.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Represents a thread-safe execution context that stores key-value pairs for use by extension methods.
+    /// </summary>
+    public class ExecutionContext
+    {
+        private readonly Dictionary<string, object> _contextData = new Dictionary<string, object>();
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Sets a value in the context by key.
+        /// </summary>
+        /// <param name="key">The key to store the value under.</param>
+        /// <param name="value">The value to store.</param>
+        public void Set(string key, object value)
+        {
+            lock (_lock)
+            {
+                _contextData[key] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value from the context by key.
+        /// </summary>
+        /// <param name="key">The key to retrieve the value for.</param>
+        /// <returns>The value associated with the key, or null if not found.</returns>
+        public object Get(string key)
+        {
+            lock (_lock)
+            {
+                return _contextData.TryGetValue(key, out var value) ? value : null;
+            }
+        }
+
+        /// <summary>
+        /// Tries to get a value from the context by key.
+        /// </summary>
+        /// <param name="key">The key to retrieve the value for.</param>
+        /// <param name="value">The value associated with the key, or null if not found.</param>
+        /// <returns>True if the key exists in the context, false otherwise.</returns>
+        public bool TryGet(string key, out object value)
+        {
+            lock (_lock)
+            {
+                return _contextData.TryGetValue(key, out value);
+            }
+        }
+
+        /// <summary>
+        /// Clears all values from the context.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _contextData.Clear();
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/Global.cs
+++ b/Platform/Platform.Examples/Global.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Provides access to the current execution context for the calling thread.
+    /// </summary>
+    public static class Global
+    {
+        private static readonly AsyncLocal<ExecutionContext> _currentContext = new AsyncLocal<ExecutionContext>();
+
+        /// <summary>
+        /// Gets the current execution context for the calling thread.
+        /// If no context exists, a new one is created.
+        /// </summary>
+        /// <returns>The current execution context.</returns>
+        public static ExecutionContext GetCurrentContext()
+        {
+            if (_currentContext.Value == null)
+            {
+                _currentContext.Value = new ExecutionContext();
+            }
+            return _currentContext.Value;
+        }
+
+        /// <summary>
+        /// Sets the current execution context for the calling thread.
+        /// </summary>
+        /// <param name="context">The execution context to set as current.</param>
+        public static void SetCurrentContext(ExecutionContext context)
+        {
+            _currentContext.Value = context;
+        }
+
+        /// <summary>
+        /// Clears the current execution context for the calling thread.
+        /// </summary>
+        public static void ClearCurrentContext()
+        {
+            _currentContext.Value = null;
+        }
+    }
+}

--- a/Platform/Platform.Examples/ObjectExtensions.cs
+++ b/Platform/Platform.Examples/ObjectExtensions.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Globalization;
+using Platform.Data.Doublets;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Provides extension methods for object conversion with support for context-based configuration.
+    /// </summary>
+    public static class ObjectExtensions
+    {
+        /// <summary>
+        /// Converts an object to DateTime using the specified format or the format from the current context.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <param name="format">Optional format string. If not provided, uses "ToDateTime.format" from the current context.</param>
+        /// <returns>A DateTime representation of the object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when obj is null.</exception>
+        /// <exception cref="FormatException">Thrown when the object cannot be converted to DateTime.</exception>
+        public static DateTime ToDateTime(this object obj, string format = null)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            // If no format is provided, try to get it from context
+            if (format == null)
+            {
+                format = Global.GetCurrentContext().Get("ToDateTime.format") as string;
+            }
+
+            // If obj is already a DateTime, return it
+            if (obj is DateTime dateTime)
+            {
+                return dateTime;
+            }
+
+            // Convert to string
+            var stringValue = obj.ToString();
+
+            // If we have a format, use it
+            if (!string.IsNullOrEmpty(format))
+            {
+                return DateTime.ParseExact(stringValue, format, CultureInfo.InvariantCulture);
+            }
+
+            // Otherwise, try default parsing
+            return DateTime.Parse(stringValue, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts an object to a Link using the specified Links instance or the instance from the current context.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <param name="links">Optional Links instance. If not provided, uses "ToLink.links" from the current context.</param>
+        /// <returns>A link representation of the object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when obj is null or links instance is not available.</exception>
+        public static ulong ToLink(this object obj, ILinks<ulong> links = null)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            // If no links instance is provided, try to get it from context
+            if (links == null)
+            {
+                links = Global.GetCurrentContext().Get("ToLink.links") as ILinks<ulong>;
+            }
+
+            if (links == null)
+            {
+                throw new ArgumentNullException(nameof(links), "Links instance not provided and not found in context.");
+            }
+
+            // If obj is already a link (ulong), return it
+            if (obj is ulong linkValue)
+            {
+                return linkValue;
+            }
+
+            // If obj can be converted to ulong, do so
+            if (obj is long || obj is int || obj is short || obj is byte)
+            {
+                return Convert.ToUInt64(obj);
+            }
+
+            // For string objects, create a link that represents the string
+            if (obj is string stringValue)
+            {
+                // This is a simplified example - in real implementation you might want to
+                // create a sequence of links representing the string
+                return links.GetOrCreate<ulong>(0, (ulong)Math.Abs(stringValue.GetHashCode()));
+            }
+
+            // For other types, create a link based on the object's hash code
+            return links.GetOrCreate<ulong>(0, (ulong)Math.Abs(obj.GetHashCode()));
+        }
+    }
+}

--- a/Platform/Platform.Examples/ObjectExtensionsExample.cs
+++ b/Platform/Platform.Examples/ObjectExtensionsExample.cs
@@ -1,0 +1,60 @@
+using System;
+using Platform.Data.Doublets;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Demonstrates the usage of object extensions with the global context system.
+    /// </summary>
+    public class ObjectExtensionsExample
+    {
+        /// <summary>
+        /// Example demonstrating ToDateTime extension with context-based format.
+        /// </summary>
+        public static void ToDateTimeExample()
+        {
+            // Set the default format in the global context
+            Global.GetCurrentContext().Set("ToDateTime.format", "dd-MM-yyyy");
+
+            // Now ToDateTime can use the context format
+            var dateString = "25-12-2024";
+            var date = dateString.ToDateTime();
+
+            Console.WriteLine($"Parsed date: {date}");
+
+            // You can also override the context format
+            var usDate = "12/25/2024";
+            var date2 = usDate.ToDateTime("MM/dd/yyyy");
+
+            Console.WriteLine($"Parsed US date: {date2}");
+        }
+
+        /// <summary>
+        /// Example demonstrating ToLink extension with context-based Links instance.
+        /// Note: This is a conceptual example. In real usage, you would initialize
+        /// a Links instance (e.g., SynchronizedLinks&lt;ulong&gt;) and set it in the context.
+        /// </summary>
+        public static void ToLinkExampleConcept()
+        {
+            // Conceptual example:
+            // Global.GetCurrentContext().Set("ToLink.links", yourLinksInstance);
+            // var obj = "example string";
+            // var link = obj.ToLink(); // Uses context Links instance
+            // var link2 = obj.ToLink(explicitLinksInstance); // Uses explicit Links instance
+
+            Console.WriteLine("ToLink example: Set 'ToLink.links' in context before calling ToLink()");
+        }
+
+        /// <summary>
+        /// Runs all examples.
+        /// </summary>
+        public static void RunAllExamples()
+        {
+            Console.WriteLine("=== ToDateTime Example ===");
+            ToDateTimeExample();
+
+            Console.WriteLine("\n=== ToLink Example ===");
+            ToLinkExampleConcept();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a global execution context system that enables extension methods to use thread-safe, context-based configuration, as requested in issue #221.

### Key Features

- **Global Context System**: Thread-safe execution context using `AsyncLocal` for proper async/await support
- **ToDateTime Extension**: Converts objects to `DateTime` with optional context-based format configuration
- **ToLink Extension**: Converts objects to Link with optional context-based Links instance

### Implementation Details

#### Files Added
- `ExecutionContext.cs`: Thread-safe key-value store for context data
- `Global.cs`: Provides `GetCurrentContext()` for accessing thread-local context
- `ObjectExtensions.cs`: Extension methods `ToDateTime()` and `ToLink()`
- `ObjectExtensionsExample.cs`: Usage examples and demonstrations

#### Usage Example

```csharp
// Set default format in context
Global.GetCurrentContext().Set("ToDateTime.format", "dd-MM-yyyy");

// Use extension with context format
var date = "25-12-2024".ToDateTime();

// Or override with explicit format
var date2 = "12/25/2024".ToDateTime("MM/dd/yyyy");
```

```csharp
// Set Links instance in context
Global.GetCurrentContext().Set("ToLink.links", linksInstance);

// Use extension with context Links
var link = someObject.ToLink();

// Or override with explicit Links instance
var link2 = someObject.ToLink(explicitLinksInstance);
```

### Architecture

- Uses `AsyncLocal<ExecutionContext>` for thread-safe, async-compatible context management
- Extension methods check for explicit parameters first, then fall back to context values
- Thread-safe dictionary operations with lock-based synchronization

## Test Plan

- [x] Build verification passed (netstandard2.0)
- [x] Code follows existing project patterns
- [x] Examples demonstrate usage from issue #221
- [ ] Manual testing of context isolation across threads
- [ ] Integration testing with actual Links instances

## Related Issue

Fixes #221

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)