### PR TITLE
Add LinksDiff functionality to detect changes in links structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-230-88b5c810
+Your prepared working directory: /tmp/gh-issue-solver-1760666391959
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-230-88b5c810
-Your prepared working directory: /tmp/gh-issue-solver-1760666391959
-
-Proceed.

--- a/Platform/Platform.Examples/LinksDiff.cs
+++ b/Platform/Platform.Examples/LinksDiff.cs
@@ -1,0 +1,208 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+using Platform.Data;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Compares two links databases and detects differences (added, removed, and modified links).
+    /// </summary>
+    public class LinksDiff
+    {
+        /// <summary>
+        /// Represents a single change in the links structure.
+        /// </summary>
+        public enum ChangeType
+        {
+            Added,
+            Removed,
+            Modified
+        }
+
+        /// <summary>
+        /// Represents a detected change between two links databases.
+        /// </summary>
+        public class LinkChange
+        {
+            public ChangeType Type { get; set; }
+            public ulong Index { get; set; }
+            public ulong? OldSource { get; set; }
+            public ulong? OldTarget { get; set; }
+            public ulong? NewSource { get; set; }
+            public ulong? NewTarget { get; set; }
+
+            public override string ToString()
+            {
+                switch (Type)
+                {
+                    case ChangeType.Added:
+                        return $"+ Link {Index}: {NewSource} -> {NewTarget}";
+                    case ChangeType.Removed:
+                        return $"- Link {Index}: {OldSource} -> {OldTarget}";
+                    case ChangeType.Modified:
+                        return $"~ Link {Index}: ({OldSource} -> {OldTarget}) => ({NewSource} -> {NewTarget})";
+                    default:
+                        return $"? Link {Index}";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compares two links databases and returns a list of changes.
+        /// </summary>
+        /// <param name="oldLinks">The old/previous state of links.</param>
+        /// <param name="newLinks">The new/current state of links.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the operation.</param>
+        /// <returns>A list of detected changes.</returns>
+        public List<LinkChange> Compare(SynchronizedLinks<ulong> oldLinks, SynchronizedLinks<ulong> newLinks, CancellationToken cancellationToken)
+        {
+            var changes = new List<LinkChange>();
+            var oldLinksMap = new Dictionary<ulong, (ulong source, ulong target)>();
+            var newLinksMap = new Dictionary<ulong, (ulong source, ulong target)>();
+
+            // Build map of old links
+            oldLinks.Each(link =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return oldLinks.Constants.Break;
+                }
+                var index = link[oldLinks.Constants.IndexPart];
+                var source = link[oldLinks.Constants.SourcePart];
+                var target = link[oldLinks.Constants.TargetPart];
+                oldLinksMap[index] = (source, target);
+                return oldLinks.Constants.Continue;
+            });
+
+            // Build map of new links
+            newLinks.Each(link =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return newLinks.Constants.Break;
+                }
+                var index = link[newLinks.Constants.IndexPart];
+                var source = link[newLinks.Constants.SourcePart];
+                var target = link[newLinks.Constants.TargetPart];
+                newLinksMap[index] = (source, target);
+                return newLinks.Constants.Continue;
+            });
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return changes;
+            }
+
+            // Find removed and modified links
+            foreach (var kvp in oldLinksMap)
+            {
+                var index = kvp.Key;
+                var oldValue = kvp.Value;
+
+                if (!newLinksMap.TryGetValue(index, out var newValue))
+                {
+                    // Link was removed
+                    changes.Add(new LinkChange
+                    {
+                        Type = ChangeType.Removed,
+                        Index = index,
+                        OldSource = oldValue.source,
+                        OldTarget = oldValue.target
+                    });
+                }
+                else if (oldValue.source != newValue.source || oldValue.target != newValue.target)
+                {
+                    // Link was modified
+                    changes.Add(new LinkChange
+                    {
+                        Type = ChangeType.Modified,
+                        Index = index,
+                        OldSource = oldValue.source,
+                        OldTarget = oldValue.target,
+                        NewSource = newValue.source,
+                        NewTarget = newValue.target
+                    });
+                }
+            }
+
+            // Find added links
+            foreach (var kvp in newLinksMap)
+            {
+                var index = kvp.Key;
+                var newValue = kvp.Value;
+
+                if (!oldLinksMap.ContainsKey(index))
+                {
+                    // Link was added
+                    changes.Add(new LinkChange
+                    {
+                        Type = ChangeType.Added,
+                        Index = index,
+                        NewSource = newValue.source,
+                        NewTarget = newValue.target
+                    });
+                }
+            }
+
+            return changes;
+        }
+
+        /// <summary>
+        /// Compares two links databases and writes the differences to a file.
+        /// </summary>
+        /// <param name="oldLinks">The old/previous state of links.</param>
+        /// <param name="newLinks">The new/current state of links.</param>
+        /// <param name="outputPath">Path to the output file where diff will be written.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the operation.</param>
+        public void CompareAndExport(SynchronizedLinks<ulong> oldLinks, SynchronizedLinks<ulong> newLinks, string outputPath, CancellationToken cancellationToken)
+        {
+            var changes = Compare(oldLinks, newLinks, cancellationToken);
+
+            using (var file = File.OpenWrite(outputPath))
+            using (var writer = new StreamWriter(file, Encoding.UTF8))
+            {
+                writer.WriteLine($"Links Diff Report");
+                writer.WriteLine($"Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                writer.WriteLine($"Total changes: {changes.Count}");
+                writer.WriteLine();
+
+                var addedCount = 0;
+                var removedCount = 0;
+                var modifiedCount = 0;
+
+                foreach (var change in changes)
+                {
+                    switch (change.Type)
+                    {
+                        case ChangeType.Added:
+                            addedCount++;
+                            break;
+                        case ChangeType.Removed:
+                            removedCount++;
+                            break;
+                        case ChangeType.Modified:
+                            modifiedCount++;
+                            break;
+                    }
+                }
+
+                writer.WriteLine($"Summary:");
+                writer.WriteLine($"  Added: {addedCount}");
+                writer.WriteLine($"  Removed: {removedCount}");
+                writer.WriteLine($"  Modified: {modifiedCount}");
+                writer.WriteLine();
+                writer.WriteLine("Changes:");
+                writer.WriteLine("--------");
+
+                foreach (var change in changes)
+                {
+                    writer.WriteLine(change.ToString());
+                }
+            }
+        }
+    }
+}

--- a/Platform/Platform.Examples/LinksDiffCLI.cs
+++ b/Platform/Platform.Examples/LinksDiffCLI.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using Platform.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Specific;
+using Platform.Data.Doublets.Decorators;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Command-line interface for comparing two links databases and detecting differences.
+    /// </summary>
+    public class LinksDiffCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            var i = 0;
+            var oldLinksFile = ConsoleHelpers.GetOrReadArgument(i++, "Old links file (baseline)", args);
+            var newLinksFile = ConsoleHelpers.GetOrReadArgument(i++, "New links file (current)", args);
+            var outputFile = ConsoleHelpers.GetOrReadArgument(i++, "Output diff file", args);
+
+            if (!File.Exists(oldLinksFile))
+            {
+                Console.WriteLine($"Error: Old links file '{oldLinksFile}' does not exist.");
+                return;
+            }
+
+            if (!File.Exists(newLinksFile))
+            {
+                Console.WriteLine($"Error: New links file '{newLinksFile}' does not exist.");
+                return;
+            }
+
+            try
+            {
+                // Create output file
+                File.Create(outputFile).Dispose();
+
+                if (!File.Exists(outputFile))
+                {
+                    Console.WriteLine($"Error: Cannot create output file '{outputFile}'.");
+                    return;
+                }
+
+                Console.WriteLine("Loading old links database...");
+                using (var cancellation = new ConsoleCancellation())
+                using (var oldMemoryAdapter = new UInt64UnitedMemoryLinks(oldLinksFile))
+                using (var oldLinksStore = new UInt64Links(oldMemoryAdapter))
+                {
+                    Console.WriteLine("Loading new links database...");
+                    using (var newMemoryAdapter = new UInt64UnitedMemoryLinks(newLinksFile))
+                    using (var newLinksStore = new UInt64Links(newMemoryAdapter))
+                    {
+                        Console.WriteLine("Comparing databases...");
+                        Console.WriteLine("Press CTRL+C to stop.");
+
+                        var oldLinks = new SynchronizedLinks<ulong>(oldLinksStore);
+                        var newLinks = new SynchronizedLinks<ulong>(newLinksStore);
+
+                        var diff = new LinksDiff();
+                        diff.CompareAndExport(oldLinks, newLinks, outputFile, cancellation.Token);
+
+                        Console.WriteLine($"Diff report written to: {outputFile}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Console.WriteLine($"Stack trace: {ex.StackTrace}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔍 Summary

This PR implements a diff tool for comparing two links databases and detecting changes (additions, removals, and modifications).

### 📋 Issue Reference
Fixes #230

### ✨ Implementation Details

This implementation adds two new classes to `Platform.Examples`:

#### 1. `LinksDiff` - Core Diff Functionality
- Compares two `SynchronizedLinks<ulong>` instances
- Detects three types of changes:
  - **Added**: Links that exist in the new database but not in the old one
  - **Removed**: Links that exist in the old database but not in the new one
  - **Modified**: Links that exist in both databases but with different source/target values
- Provides both programmatic access via `Compare()` method and file export via `CompareAndExport()` method
- Outputs a structured diff report with summary statistics

#### 2. `LinksDiffCLI` - Command-Line Interface
- Follows the same pattern as existing CLI tools (CSVExporterCLI, GEXFExporterCLI)
- Takes three parameters:
  1. Old links file (baseline)
  2. New links file (current)
  3. Output diff file path
- Supports cancellation via CTRL+C
- Provides user-friendly error messages

### 📊 Output Format

The diff report includes:
- Generation timestamp
- Total number of changes
- Summary by change type (added/removed/modified counts)
- Detailed list of all changes with:
  - Change indicator (+/-/~)
  - Link index
  - Old and new source/target values

Example output:
```
Links Diff Report
Generated: 2025-01-20 10:30:00
Total changes: 5

Summary:
  Added: 2
  Removed: 1
  Modified: 2

Changes:
--------
+ Link 10: 5 -> 7
- Link 3: 1 -> 2
~ Link 8: (2 -> 4) => (2 -> 6)
...
```

### 🏗️ Design Decisions

1. **Dictionary-based comparison**: Uses hash maps for O(1) lookup performance when comparing link indices
2. **Memory efficiency**: Builds full maps in memory for fast comparison (suitable for most use cases)
3. **Extensibility**: `LinkChange` class can be easily extended with additional metadata
4. **Consistency**: Follows existing code patterns and conventions from CSV/GEXF exporters

### 🧪 Testing

- ✅ Code compiles successfully with `dotnet build`
- ✅ Follows existing code style and patterns
- ✅ Compatible with Platform.Data.Doublets v0.6.10

### 💡 Usage Example

```csharp
using (var oldMemory = new UInt64UnitedMemoryLinks("old.links"))
using (var oldLinksStore = new UInt64Links(oldMemory))
using (var newMemory = new UInt64UnitedMemoryLinks("new.links"))
using (var newLinksStore = new UInt64Links(newMemory))
{
    var oldLinks = new SynchronizedLinks<ulong>(oldLinksStore);
    var newLinks = new SynchronizedLinks<ulong>(newLinksStore);
    
    var diff = new LinksDiff();
    diff.CompareAndExport(oldLinks, newLinks, "diff-report.txt", cancellationToken);
}
```

Or via CLI:
```bash
# Run the LinksDiffCLI with your links files
LinksDiffCLI old.links new.links diff-report.txt
```

### 🤔 Open Questions

I've posted a comment on issue #230 asking for additional clarification on requirements. The current implementation provides a solid foundation that can be extended based on feedback:
- Support for comparing snapshots at different times
- JSON/XML output formats
- Filtering options (e.g., show only additions)
- Performance optimizations for very large databases

### 🚀 Next Steps

- Await feedback on the implementation
- Add unit tests if requested
- Extend functionality based on maintainer feedback

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)