### PR TITLE
Implement FileDigramFrequencyCalculator and CLI for issue #305

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-305-1be71366
+Your prepared working directory: /tmp/gh-issue-solver-1760667944673
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-305-1be71366
-Your prepared working directory: /tmp/gh-issue-solver-1760667944673
-
-Proceed.

--- a/Platform/Platform.Examples/FileDigramFrequencyCalculator.cs
+++ b/Platform/Platform.Examples/FileDigramFrequencyCalculator.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Platform.IO;
+
+namespace Platform.Examples
+{
+    public class FileDigramFrequencyCalculator
+    {
+        private readonly ConcurrentDictionary<string, long> _digramFrequencies;
+
+        public FileDigramFrequencyCalculator()
+        {
+            _digramFrequencies = new ConcurrentDictionary<string, long>();
+        }
+
+        public IReadOnlyDictionary<string, long> DigramFrequencies => _digramFrequencies;
+
+        public void CalculateSync(string path, CancellationToken cancellationToken)
+        {
+            const int stepSize = 1024 * 1024;
+
+            using (var reader = File.OpenText(path))
+            {
+                var steps = 0;
+                char[] buffer = new char[stepSize];
+                int readChars = 0;
+                char lastCharOfPreviousChunk = '\0';
+
+                while (!cancellationToken.IsCancellationRequested && (readChars = reader.Read(buffer, 0, stepSize)) > 0)
+                {
+                    if (lastCharOfPreviousChunk != '\0')
+                    {
+                        var digram = new string(new[] { lastCharOfPreviousChunk, buffer[0] });
+                        _digramFrequencies.AddOrUpdate(digram, 1, (key, oldValue) => oldValue + 1);
+                    }
+
+                    for (int i = 0; i < readChars - 1; i++)
+                    {
+                        var digram = new string(new[] { buffer[i], buffer[i + 1] });
+                        _digramFrequencies.AddOrUpdate(digram, 1, (key, oldValue) => oldValue + 1);
+                    }
+
+                    lastCharOfPreviousChunk = buffer[readChars - 1];
+                    var totalDigrams = _digramFrequencies.Values.Sum();
+                    Console.WriteLine($"chars: {(ulong)steps * stepSize + (ulong)readChars}, digrams: {totalDigrams}, unique: {_digramFrequencies.Count}");
+                    steps++;
+                }
+            }
+        }
+
+        public async Task CalculateAsync(string path, CancellationToken cancellationToken)
+        {
+            const int stepSize = 1024 * 1024;
+            using (var reader = File.OpenText(path))
+            {
+                var steps = 0;
+                char[] buffer = new char[stepSize];
+                int readChars = 0;
+                char lastCharOfPreviousChunk = '\0';
+                ConcurrentQueue<Task> tasks = new ConcurrentQueue<Task>();
+
+                while (!cancellationToken.IsCancellationRequested && (readChars = reader.Read(buffer, 0, stepSize)) > 0)
+                {
+                    if (lastCharOfPreviousChunk != '\0')
+                    {
+                        var digram = new string(new[] { lastCharOfPreviousChunk, buffer[0] });
+                        _digramFrequencies.AddOrUpdate(digram, 1, (key, oldValue) => oldValue + 1);
+                    }
+
+                    var bufferCopy = new char[readChars];
+                    Array.Copy(buffer, bufferCopy, readChars);
+
+                    tasks.Enqueue(Task.Run(() =>
+                    {
+                        for (int i = 0; i < bufferCopy.Length - 1; i++)
+                        {
+                            var digram = new string(new[] { bufferCopy[i], bufferCopy[i + 1] });
+                            _digramFrequencies.AddOrUpdate(digram, 1, (key, oldValue) => oldValue + 1);
+                        }
+                    }));
+
+                    lastCharOfPreviousChunk = bufferCopy[readChars - 1];
+
+                    if (tasks.Count > 3)
+                    {
+                        if (tasks.TryDequeue(out var task))
+                        {
+                            await task;
+                        }
+                    }
+
+                    var totalDigrams = _digramFrequencies.Values.Sum();
+                    Console.WriteLine($"chars: {(ulong)steps * stepSize + (ulong)readChars}, digrams: {totalDigrams}, unique: {_digramFrequencies.Count}");
+                    steps++;
+                }
+
+                while (tasks.TryDequeue(out var task))
+                {
+                    await task;
+                }
+            }
+        }
+
+        public void PrintTopDigrams(int topCount = 20)
+        {
+            Console.WriteLine($"\nTop {topCount} most frequent digrams:");
+            var sortedDigrams = _digramFrequencies
+                .OrderByDescending(kvp => kvp.Value)
+                .Take(topCount);
+
+            foreach (var kvp in sortedDigrams)
+            {
+                var displayDigram = kvp.Key.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+                Console.WriteLine($"{displayDigram}: {kvp.Value}");
+            }
+        }
+
+        public void SaveToFile(string outputPath)
+        {
+            var sortedDigrams = _digramFrequencies
+                .OrderByDescending(kvp => kvp.Value)
+                .Select(kvp => $"{kvp.Key}\t{kvp.Value}");
+
+            File.WriteAllLines(outputPath, sortedDigrams);
+            Console.WriteLine($"\nDigram frequencies saved to: {outputPath}");
+        }
+    }
+}

--- a/Platform/Platform.Examples/FileDigramFrequencyCalculatorCLI.cs
+++ b/Platform/Platform.Examples/FileDigramFrequencyCalculatorCLI.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using Platform.IO;
+
+namespace Platform.Examples
+{
+    public class FileDigramFrequencyCalculatorCLI : ICommandLineInterface
+    {
+        public void Run(string[] args)
+        {
+            var fileToAnalyze = ConsoleHelpers.GetOrReadArgument(0, "File to analyze", args);
+            var outputFile = ConsoleHelpers.GetOrReadArgument(1, "Output file (optional, press Enter to skip)", args);
+
+            if (!File.Exists(fileToAnalyze))
+            {
+                Console.WriteLine("Entered file to analyze does not exist.");
+            }
+            else
+            {
+                using (var cancellation = new ConsoleCancellation())
+                {
+                    Console.WriteLine("Press CTRL+C to stop.");
+                    var calculator = new FileDigramFrequencyCalculator();
+                    calculator.CalculateSync(fileToAnalyze, cancellation.Token);
+
+                    calculator.PrintTopDigrams(20);
+
+                    if (!string.IsNullOrWhiteSpace(outputFile))
+                    {
+                        calculator.SaveToFile(outputFile);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `FileDigramFrequencyCalculator` and `FileDigramFrequencyCalculatorCLI` classes based on the existing `FileIndexer` implementation to calculate character digram (two-character sequence) frequencies in files.

### Changes
- **FileDigramFrequencyCalculator.cs**: Core calculator class with sync and async methods
  - `CalculateSync()`: Synchronous digram frequency calculation
  - `CalculateAsync()`: Asynchronous digram frequency calculation
  - `DigramFrequencies`: Property exposing calculated frequency dictionary
  - `PrintTopDigrams()`: Displays top N most frequent digrams
  - `SaveToFile()`: Exports results to file
  - Processes files in chunks (1MB default) to handle large files efficiently
  - Maintains state across chunk boundaries for accurate digram detection

- **FileDigramFrequencyCalculatorCLI.cs**: Command-line interface implementation
  - Implements `ICommandLineInterface` pattern used throughout the codebase
  - Accepts file path to analyze and optional output file path
  - Provides CTRL+C cancellation support
  - Displays top 20 most frequent digrams
  - Optionally saves complete results to file

### Test plan
- [x] Code builds successfully with `dotnet build`
- [x] Implementation follows the same patterns as `FileIndexer`
- [x] CLI follows the same interface pattern as other CLIs in the codebase
- [ ] Manual testing with sample files (requires runtime environment)

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)