### PR TITLE
Replace IHtmlHelper.Partial with IHtmlHelper.PartialAsync in WebTerminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-317-885d4883
+Your prepared working directory: /tmp/gh-issue-solver-1760669912511
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-317-885d4883
-Your prepared working directory: /tmp/gh-issue-solver-1760669912511
-
-Proceed.

--- a/Platform/Platform.Data.WebTerminal/Views/Links/Index.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Links/Index.cshtml
@@ -5,9 +5,9 @@
 <div class="link-view">
     <h2>@ViewData["Title"]</h2>
     <div class="link-description">
-        <partial name="LinkDescription" model='Model.Link' />
+        @await Html.PartialAsync("LinkDescription", Model.Link)
     </div>
     <div>
-        <partial name="LinkReferersList" model='Model.ReferersModels' />
+        @await Html.PartialAsync("LinkReferersList", Model.ReferersModels)
     </div>
 </div>

--- a/Platform/Platform.Data.WebTerminal/Views/Links/Infinite.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Links/Infinite.cshtml
@@ -23,9 +23,9 @@
         <ul>
             <li>
                 <div class="item">
-                    <partial name="LinkDescription" model="Model.Link" />
+                    @await Html.PartialAsync("LinkDescription", Model.Link)
                 </div>
-                <partial name="InfiniteLinkReferersList" model="Model.ReferersModels" />
+                @await Html.PartialAsync("InfiniteLinkReferersList", Model.ReferersModels)
             </li>
         </ul>
     </div>

--- a/Platform/Platform.Data.WebTerminal/Views/Links/InfiniteLinkReferersList.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Links/InfiniteLinkReferersList.cshtml
@@ -7,12 +7,12 @@
             <li>
                 <div class="item">
                     <a href='@Url.Action("Index", "Links", new {Id = item.Link.ToInt()})'>
-                        <partial name="LinkRefererDescription" model="item.Link" />
+                        @await Html.PartialAsync("LinkRefererDescription", item.Link)
                     </a>
                 </div>
                 @if (item.ReferersModels.Count > 0)
                 {
-                    <partial name="InfiniteLinkReferersList" model="item.ReferersModels" />
+                    @await Html.PartialAsync("InfiniteLinkReferersList", item.ReferersModels)
                 }
             </li>
         }

--- a/Platform/Platform.Data.WebTerminal/Views/Links/LinkReferersList.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Links/LinkReferersList.cshtml
@@ -5,12 +5,12 @@
     <li>
         <div class="link-referer-description">
             <a href='@Url.Action("Index", "Links", new { Id = item.Link.ToInt() })'>
-                <partial name="LinkRefererDescription" model="item.Link" />
+                @await Html.PartialAsync("LinkRefererDescription", item.Link)
             </a>
         </div>
         @if (item.ReferersModels.Count > 0)
         {
-            <partial name="LinkReferersList" model="item.ReferersModels" />
+            @await Html.PartialAsync("LinkReferersList", item.ReferersModels)
         }
     </li>
 }

--- a/Platform/Platform.Data.WebTerminal/Views/Shared/_Layout.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Shared/_Layout.cshtml
@@ -42,7 +42,7 @@
         </nav>
     </header>
     <div class="container">
-        <partial name="_CookieConsentPartial" />
+        @await Html.PartialAsync("_CookieConsentPartial")
         <main role="main" class="pb-3">
             @RenderBody()
         </main>


### PR DESCRIPTION
## Summary
This PR replaces all synchronous `<partial>` tag helpers with asynchronous `@await Html.PartialAsync()` calls across all WebTerminal views to improve performance and follow ASP.NET Core best practices.

## Changes Made
- ✅ **Views/Shared/_Layout.cshtml**: Replaced `<partial>` for `_CookieConsentPartial`
- ✅ **Views/Links/Index.cshtml**: Replaced `<partial>` for `LinkDescription` and `LinkReferersList`
- ✅ **Views/Links/Infinite.cshtml**: Replaced `<partial>` for `LinkDescription` and `InfiniteLinkReferersList`
- ✅ **Views/Links/InfiniteLinkReferersList.cshtml**: Replaced `<partial>` for `LinkRefererDescription` and recursive `InfiniteLinkReferersList`
- ✅ **Views/Links/LinkReferersList.cshtml**: Replaced `<partial>` for `LinkRefererDescription` and recursive `LinkReferersList`

## Technical Details
The `<partial>` tag helper is synchronous and blocks the rendering pipeline. By switching to `@await Html.PartialAsync()`, the views can render partial views asynchronously, which is more efficient and aligns with modern ASP.NET Core practices.

## Testing
- ✅ Local build passes (`dotnet build`)
- ⏳ Waiting for CI checks

## Issue Reference
Fixes #317

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)