### PR TITLE
[WIP] Throw exceptions on unable to convert at Integer classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-319-40f59df7
+Your prepared working directory: /tmp/gh-issue-solver-1760670728515
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-319-40f59df7
-Your prepared working directory: /tmp/gh-issue-solver-1760670728515
-
-Proceed.

--- a/Platform/Platform.Examples/GEXFExporter.cs
+++ b/Platform/Platform.Examples/GEXFExporter.cs
@@ -11,7 +11,7 @@ namespace Platform.Examples
 {
     public class GEXFExporter<TLink>
     {
-        private static readonly UncheckedConverter<TLink, long> _addressToInt64Converter = UncheckedConverter<TLink, long>.Default;
+        private static readonly CheckedConverter<TLink, long> _addressToInt64Converter = CheckedConverter<TLink, long>.Default;
 
         private readonly ILinks<TLink> _links;
 


### PR DESCRIPTION
## 🤖 AI-Powered Solution for Issue #319

This pull request addresses issue #319: **Throw exceptions on unable to convert at Integer classes**

### 📋 Issue Context

The original issue referenced conversion code from an old commit (`d05df827`) that used the `Integer<T>` class and `To` helper methods in `Platform.Helpers`. This code has since been refactored and moved to separate repositories in the linksplatform organization.

### 🔍 Investigation Findings

**Old Code Location (no longer in this repo):**
- `Platform/Platform.Helpers/Integer.cs` - Generic integer wrapper with implicit conversions
- `Platform/Platform.Helpers/To.cs` - Conversion helper methods that used a "Closest" strategy (returning max/min values on overflow)

**Current Code Architecture:**
- The `Integer<T>` pattern has been replaced with .NET's `IUnsignedNumber<T>` interface
- Conversion logic now lives in [linksplatform/Converters](https://github.com/linksplatform/Converters):
  - `CheckedConverter<TSource, TTarget>` - Throws `OverflowException` on overflow ✅
  - `UncheckedConverter<TSource, TTarget>` - Silently clamps values ⚠️

### ✨ Implementation

**Changed File:** `Platform/Platform.Examples/GEXFExporter.cs:14`

```diff
- private static readonly UncheckedConverter<TLink, long> _addressToInt64Converter = UncheckedConverter<TLink, long>.Default;
+ private static readonly CheckedConverter<TLink, long> _addressToInt64Converter = CheckedConverter<TLink, long>.Default;
```

**Why This Change:**
- When exporting links to GEXF format, link addresses are converted to `long` for XML output
- If a link address exceeds `long.MaxValue`, we should know immediately (exception) rather than silently truncating
- This prevents data corruption in exports and makes conversion failures visible

### ✅ Testing

- ✅ Code compiles successfully with no warnings or errors
- ✅ Build completed: `Platform.Examples -> bin/Debug/netstandard2.0/Platform.Examples.dll`
- ✅ No other uses of `UncheckedConverter` found in the repository

### 📊 Impact

- **Files Changed:** 1
- **Lines Changed:** 1 insertion, 1 deletion
- **Breaking Change:** ⚠️ Yes - Code that previously succeeded with truncated values will now throw `OverflowException`
- **Benefit:** Early detection of data integrity issues during link export operations

### 🎯 Alignment with Issue #319

The issue requested throwing exceptions when conversions fail at Integer classes. This PR:
1. ✅ Identifies the modern equivalent of the old `Integer<T>` conversion logic
2. ✅ Replaces silent failure (UncheckedConverter) with exception-throwing behavior (CheckedConverter)
3. ✅ Ensures conversion failures are immediately visible to developers

### 📝 Notes

Since the referenced code has been refactored into separate repositories, similar changes may be needed in:
- [linksplatform/Data](https://github.com/linksplatform/Data)
- [linksplatform/Data.Doublets](https://github.com/linksplatform/Data.Doublets)
- Other packages that use `UncheckedConverter`

This PR addresses the issue scope within the main LinksPlatform repository.

---

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)