### PR TITLE
[WIP] Binary Sequences file format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-320-29a033a6
+Your prepared working directory: /tmp/gh-issue-solver-1760671122286
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-320-29a033a6
-Your prepared working directory: /tmp/gh-issue-solver-1760671122286
-
-Proceed.

--- a/Platform/Platform.Examples/BinarySequencesExporter.cs
+++ b/Platform/Platform.Examples/BinarySequencesExporter.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Platform.Data.Doublets;
+using Platform.Data;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Exports sequences to a binary file format with two main sections:
+    /// 1. Links section for duplicate data (reusable subsequences)
+    /// 2. Sequences section for unique uncompressable sequences
+    /// </summary>
+    public class BinarySequencesExporter
+    {
+        protected SynchronizedLinks<ulong> _links;
+        protected Dictionary<ulong, ulong> _linkToIndex;
+        protected List<ulong> _reusableLinks;
+        protected List<ulong> _uniqueSequences;
+
+        public void Export(SynchronizedLinks<ulong> links, string path)
+        {
+            _links = links;
+            _linkToIndex = new Dictionary<ulong, ulong>();
+            _reusableLinks = new List<ulong>();
+            _uniqueSequences = new List<ulong>();
+
+            // Analyze links to determine which are reusable and which are unique
+            AnalyzeLinks();
+
+            // Write to binary file
+            using (var file = File.Create(path))
+            using (var writer = new BinaryWriter(file))
+            {
+                WriteBinaryFormat(writer);
+            }
+        }
+
+        protected void AnalyzeLinks()
+        {
+            var linkUsageCount = new Dictionary<ulong, int>();
+
+            // Count how many times each link is referenced
+            _links.Each(link =>
+            {
+                var linkIndex = link[_links.Constants.IndexPart];
+                var source = link[_links.Constants.SourcePart];
+                var target = link[_links.Constants.TargetPart];
+
+                // Count references
+                if (!linkUsageCount.ContainsKey(source))
+                    linkUsageCount[source] = 0;
+                linkUsageCount[source]++;
+
+                if (!linkUsageCount.ContainsKey(target))
+                    linkUsageCount[target] = 0;
+                linkUsageCount[target]++;
+
+                return _links.Constants.Continue;
+            });
+
+            // Classify links based on usage
+            _links.Each(link =>
+            {
+                var linkIndex = link[_links.Constants.IndexPart];
+
+                // Links referenced more than once are reusable
+                if (linkUsageCount.ContainsKey(linkIndex) && linkUsageCount[linkIndex] > 1)
+                {
+                    if (!_linkToIndex.ContainsKey(linkIndex))
+                    {
+                        _linkToIndex[linkIndex] = (ulong)_reusableLinks.Count;
+                        _reusableLinks.Add(linkIndex);
+                    }
+                }
+                else if (!_links.IsPartialPoint(linkIndex))
+                {
+                    _uniqueSequences.Add(linkIndex);
+                }
+
+                return _links.Constants.Continue;
+            });
+        }
+
+        protected void WriteBinaryFormat(BinaryWriter writer)
+        {
+            // File header
+            writer.Write((byte)'B');  // Magic bytes: "BSEQ"
+            writer.Write((byte)'S');
+            writer.Write((byte)'E');
+            writer.Write((byte)'Q');
+            writer.Write((ushort)1);  // Format version
+
+            // Section 1: Links section (duplicate/reusable data)
+            WriteLinksSection(writer);
+
+            // Section 2: Sequences section (unique uncompressable sequences)
+            WriteSequencesSection(writer);
+        }
+
+        protected void WriteLinksSection(BinaryWriter writer)
+        {
+            // Section header
+            writer.Write((byte)'L');
+            writer.Write((byte)'I');
+            writer.Write((byte)'N');
+            writer.Write((byte)'K');
+
+            // Number of reusable links
+            WriteVariableLength(writer, (ulong)_reusableLinks.Count);
+
+            // Write each reusable link
+            foreach (var linkIndex in _reusableLinks)
+            {
+                var link = _links.GetLink(linkIndex);
+                var source = link[_links.Constants.SourcePart];
+                var target = link[_links.Constants.TargetPart];
+
+                // Write source and target as variable length values
+                WriteVariableLength(writer, GetLinkReference(source));
+                WriteVariableLength(writer, GetLinkReference(target));
+            }
+        }
+
+        protected void WriteSequencesSection(BinaryWriter writer)
+        {
+            // Section header
+            writer.Write((byte)'S');
+            writer.Write((byte)'E');
+            writer.Write((byte)'Q');
+            writer.Write((byte)'S');
+
+            // Number of unique sequences
+            WriteVariableLength(writer, (ulong)_uniqueSequences.Count);
+
+            // Write each unique sequence
+            foreach (var linkIndex in _uniqueSequences)
+            {
+                var link = _links.GetLink(linkIndex);
+                var source = link[_links.Constants.SourcePart];
+                var target = link[_links.Constants.TargetPart];
+
+                // Write source and target as variable length values
+                WriteVariableLength(writer, GetLinkReference(source));
+                WriteVariableLength(writer, GetLinkReference(target));
+            }
+        }
+
+        protected ulong GetLinkReference(ulong linkIndex)
+        {
+            // If link is in reusable section, return its index with a flag
+            if (_linkToIndex.ContainsKey(linkIndex))
+            {
+                return _linkToIndex[linkIndex] | 0x8000000000000000UL; // Set high bit to indicate reference
+            }
+            // Otherwise return the raw link value
+            return linkIndex;
+        }
+
+        /// <summary>
+        /// Writes a variable-length encoded unsigned integer.
+        /// Uses continuation bit scheme: if high bit is 1, more bytes follow.
+        /// </summary>
+        protected void WriteVariableLength(BinaryWriter writer, ulong value)
+        {
+            while (value >= 0x80)
+            {
+                writer.Write((byte)((value & 0x7F) | 0x80));
+                value >>= 7;
+            }
+            writer.Write((byte)value);
+        }
+    }
+}

--- a/Platform/Platform.Examples/BinarySequencesExporterCLI.cs
+++ b/Platform/Platform.Examples/BinarySequencesExporterCLI.cs
@@ -25,14 +25,16 @@ namespace Platform.Examples
             }
 
             Console.WriteLine($"Opening database: {dbPath}");
-            using var links = new UnitedMemoryLinks<ulong>(dbPath);
-            var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+            using (var links = new UnitedMemoryLinks<ulong>(dbPath))
+            {
+                var synchronizedLinks = new SynchronizedLinks<ulong>(links);
 
-            Console.WriteLine($"Exporting to binary sequences format: {outputPath}");
-            var exporter = new BinarySequencesExporter();
-            exporter.Export(synchronizedLinks, outputPath);
+                Console.WriteLine($"Exporting to binary sequences format: {outputPath}");
+                var exporter = new BinarySequencesExporter();
+                exporter.Export(synchronizedLinks, outputPath);
 
-            Console.WriteLine($"Export completed successfully. File saved to: {outputPath}");
+                Console.WriteLine($"Export completed successfully. File saved to: {outputPath}");
+            }
         }
     }
 }

--- a/Platform/Platform.Examples/BinarySequencesExporterCLI.cs
+++ b/Platform/Platform.Examples/BinarySequencesExporterCLI.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Generic;
+
+namespace Platform.Examples
+{
+    public class BinarySequencesExporterCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: BinarySequencesExporterCLI <db-file-path> <output-file-path>");
+                return;
+            }
+
+            var dbPath = args[0];
+            var outputPath = args[1];
+
+            if (!File.Exists(dbPath))
+            {
+                Console.WriteLine($"Error: Database file not found: {dbPath}");
+                return;
+            }
+
+            Console.WriteLine($"Opening database: {dbPath}");
+            using var links = new UnitedMemoryLinks<ulong>(dbPath);
+            var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+
+            Console.WriteLine($"Exporting to binary sequences format: {outputPath}");
+            var exporter = new BinarySequencesExporter();
+            exporter.Export(synchronizedLinks, outputPath);
+
+            Console.WriteLine($"Export completed successfully. File saved to: {outputPath}");
+        }
+    }
+}

--- a/Platform/Platform.Examples/BinarySequencesImporter.cs
+++ b/Platform/Platform.Examples/BinarySequencesImporter.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+using Platform.Data;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Imports sequences from a binary file format with two main sections:
+    /// 1. Links section for duplicate data (reusable subsequences)
+    /// 2. Sequences section for unique uncompressable sequences
+    /// </summary>
+    public class BinarySequencesImporter
+    {
+        protected SynchronizedLinks<ulong> _links;
+        protected List<ulong> _importedReusableLinks;
+
+        public void Import(SynchronizedLinks<ulong> links, string path)
+        {
+            _links = links;
+            _importedReusableLinks = new List<ulong>();
+
+            using (var file = File.OpenRead(path))
+            using (var reader = new BinaryReader(file))
+            {
+                ReadBinaryFormat(reader);
+            }
+        }
+
+        protected void ReadBinaryFormat(BinaryReader reader)
+        {
+            // Read and validate file header
+            if (reader.ReadByte() != 'B' ||
+                reader.ReadByte() != 'S' ||
+                reader.ReadByte() != 'E' ||
+                reader.ReadByte() != 'Q')
+            {
+                throw new InvalidDataException("Invalid file format: missing BSEQ magic bytes");
+            }
+
+            var version = reader.ReadUInt16();
+            if (version != 1)
+            {
+                throw new InvalidDataException($"Unsupported format version: {version}");
+            }
+
+            // Section 1: Links section (duplicate/reusable data)
+            ReadLinksSection(reader);
+
+            // Section 2: Sequences section (unique uncompressable sequences)
+            ReadSequencesSection(reader);
+        }
+
+        protected void ReadLinksSection(BinaryReader reader)
+        {
+            // Validate section header
+            if (reader.ReadByte() != 'L' ||
+                reader.ReadByte() != 'I' ||
+                reader.ReadByte() != 'N' ||
+                reader.ReadByte() != 'K')
+            {
+                throw new InvalidDataException("Invalid links section header");
+            }
+
+            // Read number of reusable links
+            var count = ReadVariableLength(reader);
+
+            // Read each reusable link
+            for (ulong i = 0; i < count; i++)
+            {
+                var source = ReadVariableLength(reader);
+                var target = ReadVariableLength(reader);
+
+                // Resolve references if needed
+                var resolvedSource = ResolveLinkReference(source);
+                var resolvedTarget = ResolveLinkReference(target);
+
+                // Create the link in the data store
+                var linkIndex = _links.GetOrCreate(resolvedSource, resolvedTarget);
+                _importedReusableLinks.Add(linkIndex);
+            }
+        }
+
+        protected void ReadSequencesSection(BinaryReader reader)
+        {
+            // Validate section header
+            if (reader.ReadByte() != 'S' ||
+                reader.ReadByte() != 'E' ||
+                reader.ReadByte() != 'Q' ||
+                reader.ReadByte() != 'S')
+            {
+                throw new InvalidDataException("Invalid sequences section header");
+            }
+
+            // Read number of unique sequences
+            var count = ReadVariableLength(reader);
+
+            // Read each unique sequence
+            for (ulong i = 0; i < count; i++)
+            {
+                var source = ReadVariableLength(reader);
+                var target = ReadVariableLength(reader);
+
+                // Resolve references if needed
+                var resolvedSource = ResolveLinkReference(source);
+                var resolvedTarget = ResolveLinkReference(target);
+
+                // Create the link in the data store
+                _links.GetOrCreate(resolvedSource, resolvedTarget);
+            }
+        }
+
+        protected ulong ResolveLinkReference(ulong value)
+        {
+            // Check if high bit is set (indicates reference to links section)
+            if ((value & 0x8000000000000000UL) != 0)
+            {
+                var index = value & 0x7FFFFFFFFFFFFFFFUL;
+                if (index >= (ulong)_importedReusableLinks.Count)
+                {
+                    throw new InvalidDataException($"Invalid link reference: {index}");
+                }
+                return _importedReusableLinks[(int)index];
+            }
+            // Otherwise it's a direct link value
+            return value;
+        }
+
+        /// <summary>
+        /// Reads a variable-length encoded unsigned integer.
+        /// Uses continuation bit scheme: if high bit is 1, more bytes follow.
+        /// </summary>
+        protected ulong ReadVariableLength(BinaryReader reader)
+        {
+            ulong result = 0;
+            int shift = 0;
+            byte b;
+
+            do
+            {
+                b = reader.ReadByte();
+                result |= (ulong)(b & 0x7F) << shift;
+                shift += 7;
+
+                if (shift > 63)
+                {
+                    throw new InvalidDataException("Variable length integer is too large");
+                }
+            } while ((b & 0x80) != 0);
+
+            return result;
+        }
+    }
+}

--- a/Platform/Platform.Examples/BinarySequencesImporterCLI.cs
+++ b/Platform/Platform.Examples/BinarySequencesImporterCLI.cs
@@ -25,14 +25,16 @@ namespace Platform.Examples
             }
 
             Console.WriteLine($"Opening/creating database: {dbPath}");
-            using var links = new UnitedMemoryLinks<ulong>(dbPath);
-            var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+            using (var links = new UnitedMemoryLinks<ulong>(dbPath))
+            {
+                var synchronizedLinks = new SynchronizedLinks<ulong>(links);
 
-            Console.WriteLine($"Importing from binary sequences format: {binaryPath}");
-            var importer = new BinarySequencesImporter();
-            importer.Import(synchronizedLinks, binaryPath);
+                Console.WriteLine($"Importing from binary sequences format: {binaryPath}");
+                var importer = new BinarySequencesImporter();
+                importer.Import(synchronizedLinks, binaryPath);
 
-            Console.WriteLine($"Import completed successfully. Data loaded into: {dbPath}");
+                Console.WriteLine($"Import completed successfully. Data loaded into: {dbPath}");
+            }
         }
     }
 }

--- a/Platform/Platform.Examples/BinarySequencesImporterCLI.cs
+++ b/Platform/Platform.Examples/BinarySequencesImporterCLI.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Generic;
+
+namespace Platform.Examples
+{
+    public class BinarySequencesImporterCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: BinarySequencesImporterCLI <binary-file-path> <db-file-path>");
+                return;
+            }
+
+            var binaryPath = args[0];
+            var dbPath = args[1];
+
+            if (!File.Exists(binaryPath))
+            {
+                Console.WriteLine($"Error: Binary file not found: {binaryPath}");
+                return;
+            }
+
+            Console.WriteLine($"Opening/creating database: {dbPath}");
+            using var links = new UnitedMemoryLinks<ulong>(dbPath);
+            var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+
+            Console.WriteLine($"Importing from binary sequences format: {binaryPath}");
+            var importer = new BinarySequencesImporter();
+            importer.Import(synchronizedLinks, binaryPath);
+
+            Console.WriteLine($"Import completed successfully. Data loaded into: {dbPath}");
+        }
+    }
+}

--- a/experiments/binary-sequences-demo.md
+++ b/experiments/binary-sequences-demo.md
@@ -1,0 +1,83 @@
+# Binary Sequences File Format Demo
+
+This document demonstrates the usage of the Binary Sequences file format implementation.
+
+## Overview
+
+The binary sequences file format provides a compact way to backup or transmit sequences data. The format contains two main sections:
+
+1. **Links Section**: Stores duplicate/reusable subsequences
+2. **Sequences Section**: Stores unique uncompressable sequences
+
+## File Format Structure
+
+```
+[File Header]
+- Magic bytes: "BSEQ" (4 bytes)
+- Version: 1 (2 bytes)
+
+[Links Section]
+- Section header: "LINK" (4 bytes)
+- Count: variable-length encoded number of reusable links
+- Links: pairs of (source, target) as variable-length encoded values
+
+[Sequences Section]
+- Section header: "SEQS" (4 bytes)
+- Count: variable-length encoded number of unique sequences
+- Sequences: pairs of (source, target) as variable-length encoded values
+```
+
+## Variable-Length Encoding
+
+The format uses variable-length encoding for integers to save space:
+- Each byte contains 7 bits of data
+- The high bit (0x80) is the continuation flag
+- If continuation flag is set, more bytes follow
+- Numbers are encoded in little-endian 7-bit chunks
+
+## Usage Examples
+
+### Export to Binary Sequences Format
+
+```csharp
+using var links = new UnitedMemoryLinks<ulong>("data.links");
+var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+
+var exporter = new BinarySequencesExporter();
+exporter.Export(synchronizedLinks, "output.bseq");
+```
+
+### Import from Binary Sequences Format
+
+```csharp
+using var links = new UnitedMemoryLinks<ulong>("data.links");
+var synchronizedLinks = new SynchronizedLinks<ulong>(links);
+
+var importer = new BinarySequencesImporter();
+importer.Import(synchronizedLinks, "input.bseq");
+```
+
+### Command Line Usage
+
+Export:
+```bash
+BinarySequencesExporterCLI data.links output.bseq
+```
+
+Import:
+```bash
+BinarySequencesImporterCLI input.bseq data.links
+```
+
+## Key Features
+
+1. **Compact Storage**: Variable-length encoding minimizes file size
+2. **Deduplication**: Reusable subsequences are stored once in the links section
+3. **Efficiency**: References to reusable links use high-bit flag (0x8000000000000000) to distinguish from direct values
+4. **Simplicity**: Two-section structure is easy to parse and extend
+
+## Related Issues
+
+- [#320 Binary Sequences file format](https://github.com/konard/LinksPlatform/issues/320)
+- [#29 Links data structure as a binary data protocol](https://github.com/konard/LinksPlatform/issues/29)
+- [#194 Universal Links String file format](https://github.com/konard/LinksPlatform/issues/194)


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request implements a binary sequences file format for the LinksPlatform project.

### 📋 Issue Reference
Fixes #320

### 🎯 Implementation Overview

The binary sequences file format provides a compact way to backup or transmit sequences data with two main sections:

1. **Links Section**: Stores duplicate/reusable subsequences
2. **Sequences Section**: Stores unique uncompressable sequences

### 📝 Implementation Details

#### File Format Structure

```
[File Header]
- Magic bytes: "BSEQ" (4 bytes)
- Version: 1 (2 bytes)

[Links Section]
- Section header: "LINK" (4 bytes)
- Count: variable-length encoded number of reusable links
- Links: pairs of (source, target) as variable-length encoded values

[Sequences Section]
- Section header: "SEQS" (4 bytes)
- Count: variable-length encoded number of unique sequences
- Sequences: pairs of (source, target) as variable-length encoded values
```

#### Key Features

- **Variable-Length Encoding**: Minimizes file size using 7-bit chunks with continuation flags
- **Deduplication**: Reusable subsequences stored once in links section
- **Efficient References**: High-bit flag (0x8000000000000000) distinguishes references from direct values
- **Simple Structure**: Two-section format is easy to parse and extend

#### Files Added

- `Platform.Examples/BinarySequencesExporter.cs` - Export sequences to binary format
- `Platform.Examples/BinarySequencesImporter.cs` - Import sequences from binary format
- `Platform.Examples/BinarySequencesExporterCLI.cs` - Command-line exporter interface
- `Platform.Examples/BinarySequencesImporterCLI.cs` - Command-line importer interface
- `experiments/binary-sequences-demo.md` - Documentation and usage examples

### 🔗 Related Issues

- #320 Binary Sequences file format
- #29 Links data structure as a binary data protocol
- #194 Universal Links String file format

### ✅ Testing

- Local build passes with 0 errors
- C# 7.3 compatibility maintained
- Follows existing codebase patterns (CSV/GEXF exporters)

### 📖 Usage Examples

**Export:**
```bash
BinarySequencesExporterCLI data.links output.bseq
```

**Import:**
```bash
BinarySequencesImporterCLI input.bseq data.links
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>