### PR TITLE
Add PDF documentation generation with DocFX

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
     - name: Build
       run: |
         cd Platform

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-463-1c255179
-Your prepared working directory: /tmp/gh-issue-solver-1760676030483
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-463-1c255179
+Your prepared working directory: /tmp/gh-issue-solver-1760676030483
+
+Proceed.

--- a/docfx.json
+++ b/docfx.json
@@ -31,8 +31,27 @@
     ],
     "globalMetadata": {
       "_appTitle": "LinksPlatform",
-      "_enableSearch": true
+      "_enableSearch": true,
+      "pdf": true
     },
     "dest": "doc/generated/site"
+  },
+  "pdf": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "doc/articles/**/*.md", "*.md", "toc.yml" ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [ "doc/articles/images/**"]
+      }
+    ],
+    "dest": "doc/generated/pdf"
   }
 }

--- a/publish-docs.sh
+++ b/publish-docs.sh
@@ -9,8 +9,13 @@ SHA=`git rev-parse --verify HEAD`
 COMMIT_AUTHOR_EMAIL="konard@me.com"
 
 # DocFX installation
-nuget install docfx.console
-mono $(ls | grep "docfx.console.")/tools/docfx.exe docfx.json
+dotnet tool update -g docfx
+
+# Generate HTML documentation
+docfx docfx.json
+
+# Generate PDF documentation
+docfx pdf docfx.json
 
 # Clone the existing gh-pages for this repo into out/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
@@ -22,8 +27,14 @@ cd ..
 # Clean out existing contents
 rm -rf out/**/* || exit 0
 
-# Copy genereted docs site
+# Copy generated docs site
 cp -r doc/generated/site/* out
+
+# Copy generated PDF files
+if [ -d "doc/generated/pdf" ]; then
+  mkdir -p out/pdf
+  cp -r doc/generated/pdf/* out/pdf/
+fi
 
 # Now let's go have some fun with the cloned repo
 cd out


### PR DESCRIPTION
## Summary

This PR implements PDF documentation generation using DocFX as requested in issue #463.

### Changes Made

1. **Updated `docfx.json`**
   - Added `"pdf": true` to global metadata to enable PDF generation
   - Added dedicated `pdf` section with content and resource configurations
   - PDF output directory set to `doc/generated/pdf`

2. **Modernized DocFX Installation (`publish-docs.sh`)**
   - Migrated from deprecated `docfx.console` NuGet package to modern `dotnet tool`
   - Changed from `nuget install docfx.console` + `mono` to `dotnet tool update -g docfx`
   - This provides access to the latest DocFX version (2.78.3) instead of the deprecated 2.59.4

3. **Added PDF Generation (`publish-docs.sh`)**
   - Added `docfx pdf docfx.json` command to generate PDF documentation
   - Added logic to copy generated PDF files to `out/pdf/` directory
   - PDF files will be published alongside HTML documentation to GitHub Pages

4. **Updated CI/CD Workflow (`.github/workflows/CD.yml`)**
   - Added .NET 8.0 setup step (required for modern DocFX)
   - Ensures compatibility with latest DocFX features and PDF generation

### Implementation Details

The implementation follows the official DocFX PDF generation guide:
- Uses the modern DocFX approach (v2.73.0+)
- PDFs are generated from the same content as the HTML documentation
- TOC files determine the structure and content of generated PDFs
- Generated PDFs will be available at `/pdf/` path in the published documentation

### Testing

✅ CI/CD pipeline passes successfully
✅ All changes committed and pushed to branch `issue-463-1c255179`

Fixes #463