### PR TITLE
Fix bug when scrolling WebTerminal with mouse wheel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-497-13fc58fa
-Your prepared working directory: /tmp/gh-issue-solver-1760680893395
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-497-13fc58fa
+Your prepared working directory: /tmp/gh-issue-solver-1760680893395
+
+Proceed.

--- a/Platform/Platform.Data.WebTerminal/wwwroot/js/infinite.js
+++ b/Platform/Platform.Data.WebTerminal/wwwroot/js/infinite.js
@@ -138,6 +138,22 @@ $(document).ready(function () {
         }
     });
 
+    $(window).on('wheel', function (e) {
+        if (ignoreScrollEvent)
+            return;
+
+        // Use a small delay to ensure the scroll position has updated
+        setTimeout(function() {
+            var element = document.elementFromPoint(document.body.clientWidth / 2, document.body.clientHeight / 2);
+
+            if ($(element).is(".item"))
+            {
+                var item = $(element);
+                MoveToItem(item, true);
+            }
+        }, 50);
+    });
+
     $(window).scroll(function () {
         if (ignoreScrollEvent)
             return;


### PR DESCRIPTION
## Summary
Fixes the bug where the focused link didn't update when scrolling with the mouse wheel in WebTerminal.

## Changes
- Added a `wheel` event handler to detect mouse wheel scrolling
- The handler checks which element is at the center of the viewport after scrolling
- Focus now properly updates to the centered link when using mouse wheel

## Technical Details
The original implementation only had a `scroll` event handler, which wasn't sufficient for proper focus updates during mouse wheel scrolling. The new `wheel` event handler includes a small delay (50ms) to ensure the scroll position has updated before checking which element is centered.

## Testing
- ✅ Build passes locally and in CI
- ✅ All existing functionality preserved
- ✅ Focus updates correctly on mouse wheel scroll

Fixes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)