### PR TITLE
WakaTime local proxy server for immediate data storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-519-63ba37be
-Your prepared working directory: /tmp/gh-issue-solver-1760685697597
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-519-63ba37be
+Your prepared working directory: /tmp/gh-issue-solver-1760685697597
+
+Proceed.

--- a/Platform/Platform.Data.WakaTimeProxy/Controllers/HeartbeatsController.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Controllers/HeartbeatsController.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Platform.Data.WakaTimeProxy.Models;
+
+namespace Platform.Data.WakaTimeProxy.Controllers
+{
+    [Route("api/v1/users/{user}")]
+    [ApiController]
+    public class HeartbeatsController : ControllerBase
+    {
+        private readonly IHeartbeatStorage _storage;
+        private readonly IWakaTimeForwarder _forwarder;
+
+        public HeartbeatsController(IHeartbeatStorage storage, IWakaTimeForwarder forwarder)
+        {
+            _storage = storage;
+            _forwarder = forwarder;
+        }
+
+        // POST api/v1/users/{user}/heartbeats
+        [HttpPost("heartbeats")]
+        public async Task<IActionResult> PostHeartbeat(string user, [FromBody] Heartbeat heartbeat)
+        {
+            if (heartbeat == null)
+                return BadRequest("Invalid heartbeat data");
+
+            // Store locally first (this is the priority according to the issue)
+            await _storage.StoreHeartbeatAsync(heartbeat);
+
+            // Try to forward to WakaTime API (optional)
+            var apiKey = Request.Headers["Authorization"].ToString().Replace("Basic ", "");
+            _ = Task.Run(async () => await _forwarder.ForwardHeartbeatAsync(user, heartbeat, apiKey));
+
+            return Ok(new { success = true });
+        }
+
+        // POST api/v1/users/{user}/heartbeats.bulk
+        [HttpPost("heartbeats.bulk")]
+        public async Task<IActionResult> PostHeartbeatsBulk(string user, [FromBody] List<Heartbeat> heartbeats)
+        {
+            if (heartbeats == null || heartbeats.Count == 0)
+                return BadRequest("Invalid heartbeat data");
+
+            // Store locally first (this is the priority according to the issue)
+            await _storage.StoreHeartbeatsAsync(heartbeats);
+
+            // Try to forward to WakaTime API (optional)
+            var apiKey = Request.Headers["Authorization"].ToString().Replace("Basic ", "");
+            _ = Task.Run(async () => await _forwarder.ForwardHeartbeatsAsync(user, heartbeats, apiKey));
+
+            return Ok(new { success = true });
+        }
+
+        // GET api/v1/users/{user}/heartbeats?date=yyyy-MM-dd
+        [HttpGet("heartbeats")]
+        public async Task<IActionResult> GetHeartbeats(string user, [FromQuery] string date)
+        {
+            if (string.IsNullOrEmpty(date))
+                return BadRequest("Date parameter is required");
+
+            var heartbeats = await _storage.GetHeartbeatsByDateAsync(date);
+            return Ok(new { data = heartbeats });
+        }
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Models/Heartbeat.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Models/Heartbeat.cs
@@ -1,0 +1,41 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Platform.Data.WakaTimeProxy.Models
+{
+    public class Heartbeat
+    {
+        [JsonProperty("entity")]
+        public string Entity { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("time")]
+        public double Time { get; set; }
+
+        [JsonProperty("project")]
+        public string Project { get; set; }
+
+        [JsonProperty("branch")]
+        public string Branch { get; set; }
+
+        [JsonProperty("language")]
+        public string Language { get; set; }
+
+        [JsonProperty("dependencies")]
+        public string[] Dependencies { get; set; }
+
+        [JsonProperty("lines")]
+        public int? Lines { get; set; }
+
+        [JsonProperty("lineno")]
+        public int? LineNo { get; set; }
+
+        [JsonProperty("cursorpos")]
+        public int? CursorPos { get; set; }
+
+        [JsonProperty("is_write")]
+        public bool? IsWrite { get; set; }
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Platform.Data.WakaTimeProxy.csproj
+++ b/Platform/Platform.Data.WakaTimeProxy/Platform.Data.WakaTimeProxy.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Platform/Platform.Data.WakaTimeProxy/Program.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Program.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .UseUrls("http://localhost:52595"); // WakaTime default API endpoint port
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/README.md
+++ b/Platform/Platform.Data.WakaTimeProxy/README.md
@@ -1,0 +1,95 @@
+# Platform.Data.WakaTimeProxy
+
+A local proxy server for WakaTime that stores heartbeat data locally as soon as it's received, solving the slow export problem from WakaTime.
+
+## Features
+
+- **Immediate Local Storage**: Stores all WakaTime heartbeats locally in real-time
+- **Fast Data Access**: Heartbeats are saved to JSON Lines format for quick retrieval
+- **Optional Forwarding**: Can optionally forward heartbeats to the official WakaTime API
+- **WakaTime API Compatible**: Implements the same API endpoints as WakaTime
+
+## How It Works
+
+The proxy intercepts heartbeat data from WakaTime plugins and:
+1. **Immediately stores** them locally (priority)
+2. Optionally forwards them to WakaTime API in the background
+
+This ensures your data is captured locally without waiting for WakaTime's slow export.
+
+## Installation
+
+1. Build the project:
+```bash
+cd Platform/Platform.Data.WakaTimeProxy
+dotnet build
+```
+
+2. Run the proxy server:
+```bash
+dotnet run
+```
+
+The server will start on `http://localhost:52595` (WakaTime's default API endpoint port).
+
+## Configuration
+
+Edit `appsettings.json`:
+
+```json
+{
+  "WakaTime": {
+    "ForwardingEnabled": false
+  }
+}
+```
+
+- Set `ForwardingEnabled` to `true` if you want heartbeats forwarded to WakaTime API
+- Set to `false` to only store locally
+
+## Configuring WakaTime Plugins
+
+Point your WakaTime plugin to use the local proxy instead of the official API:
+
+1. Set the WakaTime API URL environment variable:
+```bash
+export WAKATIME_API_URL=http://localhost:52595/api
+```
+
+Or configure in your plugin settings to use `http://localhost:52595/api` as the API endpoint.
+
+## Data Storage
+
+Heartbeats are stored in JSON Lines format at:
+- **Windows**: `%LocalAppData%\WakaTimeProxy\heartbeats\`
+- **Linux/Mac**: `~/.local/share/WakaTimeProxy/heartbeats/`
+
+Files are organized by date: `YYYY-MM-DD.jsonl`
+
+Each line contains a JSON object representing one heartbeat.
+
+## API Endpoints
+
+The proxy implements the following WakaTime API endpoints:
+
+- `POST /api/v1/users/{user}/heartbeats` - Store a single heartbeat
+- `POST /api/v1/users/{user}/heartbeats.bulk` - Store multiple heartbeats (up to 25)
+- `GET /api/v1/users/{user}/heartbeats?date=YYYY-MM-DD` - Retrieve heartbeats for a specific date
+
+## Benefits
+
+- **No More Slow Exports**: Data is immediately available locally
+- **Data Ownership**: Your coding activity is stored on your machine
+- **Offline Support**: Works without internet connection
+- **Fast Queries**: Direct file access for quick data retrieval
+
+## Troubleshooting
+
+If the proxy isn't receiving data:
+1. Verify the WakaTime plugin is configured to use the local endpoint
+2. Check that the proxy is running on port 52595
+3. Ensure firewall isn't blocking the connection
+
+## License
+
+Same as LinksPlatform project.

--- a/Platform/Platform.Data.WakaTimeProxy/Services/FileHeartbeatStorage.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Services/FileHeartbeatStorage.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Platform.Data.WakaTimeProxy.Models;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public class FileHeartbeatStorage : IHeartbeatStorage
+    {
+        private readonly string _storageDirectory;
+        private readonly object _lockObject = new object();
+
+        public FileHeartbeatStorage()
+        {
+            _storageDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "WakaTimeProxy",
+                "heartbeats"
+            );
+
+            if (!Directory.Exists(_storageDirectory))
+            {
+                Directory.CreateDirectory(_storageDirectory);
+            }
+        }
+
+        public async Task StoreHeartbeatAsync(Heartbeat heartbeat)
+        {
+            await StoreHeartbeatsAsync(new[] { heartbeat });
+        }
+
+        public async Task StoreHeartbeatsAsync(IEnumerable<Heartbeat> heartbeats)
+        {
+            var heartbeatsList = heartbeats.ToList();
+            if (!heartbeatsList.Any())
+                return;
+
+            var date = DateTimeOffset.FromUnixTimeSeconds((long)heartbeatsList.First().Time).ToString("yyyy-MM-dd");
+            var filePath = GetFilePathForDate(date);
+
+            var jsonLines = heartbeatsList.Select(h => JsonConvert.SerializeObject(h));
+
+            lock (_lockObject)
+            {
+                File.AppendAllLines(filePath, jsonLines);
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public async Task<IEnumerable<Heartbeat>> GetHeartbeatsByDateAsync(string date)
+        {
+            var filePath = GetFilePathForDate(date);
+
+            if (!File.Exists(filePath))
+            {
+                return Enumerable.Empty<Heartbeat>();
+            }
+
+            var lines = await File.ReadAllLinesAsync(filePath);
+            return lines
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .Select(line => JsonConvert.DeserializeObject<Heartbeat>(line))
+                .ToList();
+        }
+
+        private string GetFilePathForDate(string date)
+        {
+            return Path.Combine(_storageDirectory, $"{date}.jsonl");
+        }
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Services/IHeartbeatStorage.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Services/IHeartbeatStorage.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Platform.Data.WakaTimeProxy.Models;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public interface IHeartbeatStorage
+    {
+        Task StoreHeartbeatAsync(Heartbeat heartbeat);
+        Task StoreHeartbeatsAsync(IEnumerable<Heartbeat> heartbeats);
+        Task<IEnumerable<Heartbeat>> GetHeartbeatsByDateAsync(string date);
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Services/IWakaTimeForwarder.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Services/IWakaTimeForwarder.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Platform.Data.WakaTimeProxy.Models;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public interface IWakaTimeForwarder
+    {
+        Task<bool> ForwardHeartbeatAsync(string user, Heartbeat heartbeat, string apiKey);
+        Task<bool> ForwardHeartbeatsAsync(string user, IEnumerable<Heartbeat> heartbeats, string apiKey);
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Services/WakaTimeForwarder.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Services/WakaTimeForwarder.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Platform.Data.WakaTimeProxy.Models;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public class WakaTimeForwarder : IWakaTimeForwarder
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+        private readonly bool _forwardingEnabled;
+
+        public WakaTimeForwarder(HttpClient httpClient, IConfiguration configuration)
+        {
+            _httpClient = httpClient;
+            _configuration = configuration;
+            _forwardingEnabled = _configuration.GetValue<bool>("WakaTime:ForwardingEnabled", false);
+
+            _httpClient.BaseAddress = new Uri("https://api.wakatime.com/");
+        }
+
+        public async Task<bool> ForwardHeartbeatAsync(string user, Heartbeat heartbeat, string apiKey)
+        {
+            if (!_forwardingEnabled || string.IsNullOrEmpty(apiKey))
+                return false;
+
+            return await ForwardHeartbeatsAsync(user, new[] { heartbeat }, apiKey);
+        }
+
+        public async Task<bool> ForwardHeartbeatsAsync(string user, IEnumerable<Heartbeat> heartbeats, string apiKey)
+        {
+            if (!_forwardingEnabled || string.IsNullOrEmpty(apiKey))
+                return false;
+
+            try
+            {
+                var heartbeatsList = heartbeats.ToList();
+                var endpoint = heartbeatsList.Count > 1
+                    ? $"api/v1/users/{user}/heartbeats.bulk"
+                    : $"api/v1/users/{user}/heartbeats";
+
+                var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes($"{apiKey}:")));
+
+                var content = heartbeatsList.Count > 1
+                    ? JsonConvert.SerializeObject(heartbeatsList)
+                    : JsonConvert.SerializeObject(heartbeatsList.First());
+
+                request.Content = new StringContent(content, Encoding.UTF8, "application/json");
+
+                var response = await _httpClient.SendAsync(request);
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception)
+            {
+                // Log error but don't fail the local storage
+                return false;
+            }
+        }
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/Startup.cs
+++ b/Platform/Platform.Data.WakaTimeProxy/Startup.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Platform.Data.WakaTimeProxy
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddSingleton<IHeartbeatStorage, FileHeartbeatStorage>();
+            services.AddHttpClient<IWakaTimeForwarder, WakaTimeForwarder>();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvc();
+        }
+    }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/appsettings.Development.json
+++ b/Platform/Platform.Data.WakaTimeProxy/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/Platform/Platform.Data.WakaTimeProxy/appsettings.json
+++ b/Platform/Platform.Data.WakaTimeProxy/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "WakaTime": {
+    "ForwardingEnabled": false
+  }
+}

--- a/Platform/Platform.sln
+++ b/Platform/Platform.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.MasterServer"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.ConsoleTerminal", "Platform.Data.ConsoleTerminal\Platform.Data.ConsoleTerminal.csproj", "{85D097CE-614E-4351-920B-45BD35AE5A84}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.WakaTimeProxy", "Platform.Data.WakaTimeProxy\Platform.Data.WakaTimeProxy.csproj", "{B8C3F7E5-1A2D-4E6F-9B3C-8D7A4F5E6C9A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8C3F7E5-1A2D-4E6F-9B3C-8D7A4F5E6C9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8C3F7E5-1A2D-4E6F-9B3C-8D7A4F5E6C9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8C3F7E5-1A2D-4E6F-9B3C-8D7A4F5E6C9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8C3F7E5-1A2D-4E6F-9B3C-8D7A4F5E6C9A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## 🎯 Solution: WakaTime Local Proxy Server

This PR implements a local proxy server that intercepts WakaTime heartbeats and stores them locally immediately, solving the slow export problem mentioned in issue #519.

### 📋 Issue Reference
Fixes #519

### 🚀 Implementation Overview

Created a new ASP.NET Core 2.2 project `Platform.Data.WakaTimeProxy` that acts as a local proxy for the WakaTime API.

### ✨ Key Features

1. **Immediate Local Storage** 
   - All heartbeats are stored locally as soon as they're received
   - Uses JSON Lines (.jsonl) format for efficient appending and reading
   - Data stored in user's local application data directory
   - Files organized by date (YYYY-MM-DD.jsonl)

2. **WakaTime API Compatibility**
   - Implements standard WakaTime API endpoints:
     - `POST /api/v1/users/{user}/heartbeats` - Single heartbeat
     - `POST /api/v1/users/{user}/heartbeats.bulk` - Multiple heartbeats
     - `GET /api/v1/users/{user}/heartbeats?date=YYYY-MM-DD` - Retrieve by date

3. **Optional Forwarding**
   - Can forward heartbeats to official WakaTime API (disabled by default)
   - Forwarding happens asynchronously to not block local storage
   - Configurable via `appsettings.json`

4. **Fast Access**
   - No need to wait for WakaTime's slow export
   - Direct file system access for quick queries
   - Data immediately available after each coding session

### 📁 Project Structure

```
Platform/Platform.Data.WakaTimeProxy/
├── Controllers/
│   └── HeartbeatsController.cs       # API endpoints implementation
├── Models/
│   └── Heartbeat.cs                  # Heartbeat data model
├── Services/
│   ├── IHeartbeatStorage.cs          # Storage interface
│   ├── FileHeartbeatStorage.cs       # File-based storage implementation
│   ├── IWakaTimeForwarder.cs         # Forwarder interface
│   └── WakaTimeForwarder.cs          # WakaTime API forwarder
├── Program.cs                         # Application entry point
├── Startup.cs                         # Service configuration
├── appsettings.json                   # Configuration
└── README.md                          # Usage documentation
```

### 🔧 How to Use

1. **Build and run the proxy:**
   ```bash
   cd Platform/Platform.Data.WakaTimeProxy
   dotnet run
   ```
   Server starts on `http://localhost:52595`

2. **Configure WakaTime plugins:**
   Set environment variable:
   ```bash
   export WAKATIME_API_URL=http://localhost:52595/api
   ```

3. **Access stored data:**
   - Windows: `%LocalAppData%\WakaTimeProxy\heartbeats\`
   - Linux/Mac: `~/.local/share/WakaTimeProxy/heartbeats/`

### 💾 Data Storage Location

Heartbeats are stored in:
- **Windows**: `%LocalAppData%\WakaTimeProxy\heartbeats\YYYY-MM-DD.jsonl`
- **Linux/Mac**: `~/.local/share/WakaTimeProxy/heartbeats/YYYY-MM-DD.jsonl`

Each line in the file contains a complete JSON heartbeat object.

### ⚙️ Configuration

In `appsettings.json`:
```json
{
  "WakaTime": {
    "ForwardingEnabled": false
  }
}
```

Set `ForwardingEnabled` to `true` to also send heartbeats to WakaTime's servers.

### ✅ Testing

Build verification:
```bash
cd Platform/Platform.Data.WakaTimeProxy
dotnet build
```

Build succeeds with 0 errors (warnings are about netcoreapp2.2 being EOL, consistent with other Platform projects).

### 📝 Changes Made

- Added new project `Platform.Data.WakaTimeProxy` to Platform solution
- Implemented WakaTime-compatible API endpoints
- Created local file-based storage system
- Added optional forwarding to official WakaTime API
- Included comprehensive README with usage instructions

### 🎯 Benefits

- ✅ **No more slow exports** - Data immediately available locally
- ✅ **Data ownership** - Your coding activity stays on your machine
- ✅ **Offline support** - Works without internet connection
- ✅ **Fast queries** - Direct file access instead of API rate limits
- ✅ **Privacy** - Optional forwarding gives you control

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>