### PR TITLE
Add read and write UI modes toggle button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-538-7b6a5102
+Your prepared working directory: /tmp/gh-issue-solver-1760688608002
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-538-7b6a5102
-Your prepared working directory: /tmp/gh-issue-solver-1760688608002
-
-Proceed.

--- a/Platform/Platform.Data.WebTerminal/Views/Links/Infinite.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Links/Infinite.cshtml
@@ -15,6 +15,9 @@
     <!-- <link href='http://fonts.googleapis.com/css?family=Open+Sans&v1' rel='stylesheet' type='text/css'> -->
 </head>
 <body>
+    <button id="view-mode-toggle" title="Toggle between read and write mode">
+        <span id="view-mode-icon">👁</span>
+    </button>
     <div id="query">
         <div id="query-logo">links</div>
         <input type="text" autocomplete="off" spellcheck="false" tabindex="0" />

--- a/Platform/Platform.Data.WebTerminal/Views/Shared/_Layout.cshtml
+++ b/Platform/Platform.Data.WebTerminal/Views/Shared/_Layout.cshtml
@@ -36,6 +36,11 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
+                        <li class="nav-item">
+                            <button id="view-mode-toggle" class="btn btn-link nav-link text-dark" title="Toggle between read and write mode">
+                                <span id="view-mode-icon">👁</span>
+                            </button>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/Platform/Platform.Data.WebTerminal/wwwroot/css/infinite/style.css
+++ b/Platform/Platform.Data.WebTerminal/wwwroot/css/infinite/style.css
@@ -164,16 +164,60 @@ ul
 	font: 20px Sans-serif, Arial, Helvetica;
 	font-weight: lighter;
 	font-variant: small-caps;
-	
+
 	/*
 	padding: 7px 0px 0px 37px;
 	font: 16px Sans-serif, Arial, Helvetica;
 	*/
-	
+
 	font-style: italic;
 	background-color: rgba(31, 31, 31, 0.6);
 	-webkit-border-radius: 7px;
     -moz-border-radius: 7px;
     border-radius: 7px;
     /*text-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);*/
+}
+
+/* View mode toggle button for infinite view */
+#view-mode-toggle
+{
+	z-index: 15;
+	position: fixed;
+	top: 20px;
+	right: 20px;
+	border: 1px solid transparent;
+	background: #888;
+	padding: 8px 12px;
+	cursor: pointer;
+	font-size: 1.5rem;
+	color: #EEE;
+	-webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 1px 0 0 rgba(255, 255, 255, 0.1);
+    -moz-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 1px 0 0 rgba(255, 255, 255, 0.1);
+    box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 1px 0 0 rgba(255, 255, 255, 0.1);
+	-webkit-border-radius: 5px;
+	-moz-border-radius: 5px;
+	border-radius: 5px;
+	transition: transform 0.2s ease;
+}
+
+#view-mode-toggle:hover
+{
+	transform: scale(1.1);
+	background: #999;
+}
+
+#view-mode-toggle:focus
+{
+	outline: none;
+}
+
+/* Optional: Add different styles for read and write modes */
+body.read-mode
+{
+	/* Read mode styles can be added here if needed */
+}
+
+body.write-mode
+{
+	/* Write mode styles can be added here if needed */
 }

--- a/Platform/Platform.Data.WebTerminal/wwwroot/css/site.css
+++ b/Platform/Platform.Data.WebTerminal/wwwroot/css/site.css
@@ -54,3 +54,31 @@ body {
   height: 60px;
   line-height: 60px; /* Vertically center the text there */
 }
+
+/* View mode toggle button */
+#view-mode-toggle {
+  font-size: 1.5rem;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  border: none;
+  background: none;
+  transition: transform 0.2s ease;
+}
+
+#view-mode-toggle:hover {
+  transform: scale(1.2);
+}
+
+#view-mode-toggle:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+/* Optional: Add different styles for read and write modes */
+body.read-mode {
+  /* Read mode styles can be added here if needed */
+}
+
+body.write-mode {
+  /* Write mode styles can be added here if needed */
+}

--- a/Platform/Platform.Data.WebTerminal/wwwroot/js/infinite.js
+++ b/Platform/Platform.Data.WebTerminal/wwwroot/js/infinite.js
@@ -55,6 +55,35 @@ $(document).ready(function () {
     surface = $("#surface")[0];
     query = $("#query")[0];
 
+    // View mode toggle functionality
+    var viewMode = localStorage.getItem('viewMode') || 'read';
+
+    function applyViewMode(mode) {
+        var body = document.body;
+        var icon = document.getElementById('view-mode-icon');
+
+        if (mode === 'read') {
+            body.classList.remove('write-mode');
+            body.classList.add('read-mode');
+            if (icon) icon.textContent = '👁';
+        } else {
+            body.classList.remove('read-mode');
+            body.classList.add('write-mode');
+            if (icon) icon.textContent = '✎';
+        }
+
+        localStorage.setItem('viewMode', mode);
+    }
+
+    // Apply initial mode
+    applyViewMode(viewMode);
+
+    // Toggle button event listener
+    $('#view-mode-toggle').click(function() {
+        viewMode = (viewMode === 'read') ? 'write' : 'read';
+        applyViewMode(viewMode);
+    });
+
     $(".item").click(function (e) {
         if (e.which == mouseButton.left)
         {

--- a/Platform/Platform.Data.WebTerminal/wwwroot/js/site.js
+++ b/Platform/Platform.Data.WebTerminal/wwwroot/js/site.js
@@ -2,3 +2,39 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+// View mode toggle functionality
+(function() {
+    // Initialize view mode from localStorage or default to 'read'
+    var viewMode = localStorage.getItem('viewMode') || 'read';
+
+    function applyViewMode(mode) {
+        var body = document.body;
+        var icon = document.getElementById('view-mode-icon');
+
+        if (mode === 'read') {
+            body.classList.remove('write-mode');
+            body.classList.add('read-mode');
+            if (icon) icon.textContent = '👁';
+        } else {
+            body.classList.remove('read-mode');
+            body.classList.add('write-mode');
+            if (icon) icon.textContent = '✎';
+        }
+
+        localStorage.setItem('viewMode', mode);
+    }
+
+    // Apply initial mode on page load
+    document.addEventListener('DOMContentLoaded', function() {
+        applyViewMode(viewMode);
+
+        var toggleButton = document.getElementById('view-mode-toggle');
+        if (toggleButton) {
+            toggleButton.addEventListener('click', function() {
+                viewMode = (viewMode === 'read') ? 'write' : 'read';
+                applyViewMode(viewMode);
+            });
+        }
+    });
+})();


### PR DESCRIPTION
## Summary

Implements a single toggle button that switches between read-view and write-view modes as requested in issue #538.

### Features

- **Single toggle button** that switches between two modes:
  - **Read-view mode**: Displays eye symbol (👁)
  - **Write-view mode**: Displays pencil symbol (✎)
- **Persistent state**: The selected mode is saved in localStorage and restored on page reload
- **Consistent UI**: Toggle button is available in both the main layout navigation and the infinite view interface
- **Smooth transitions**: Button has hover effects and smooth animations

### Implementation Details

- Added toggle button to the navigation bar in `_Layout.cshtml`
- Added floating toggle button to the infinite view in `Infinite.cshtml`
- Implemented JavaScript toggle functionality in both `site.js` and `infinite.js`
- Added CSS styling for the button in both `site.css` and `infinite/style.css`
- The body element receives `read-mode` or `write-mode` CSS classes that can be used to style content differently based on the current mode

### Test Plan

- [x] Toggle button appears in the navigation bar on standard pages
- [x] Toggle button appears as a floating button on the infinite view
- [x] Clicking the button toggles between eye (👁) and pencil (✎) symbols
- [x] The selected mode persists across page reloads
- [x] Button has proper hover effects and styling

Fixes #538

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)