### PR TITLE
Add PostgreSQL comparison reference to README files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-543-2b68df72
-Your prepared working directory: /tmp/gh-issue-solver-1760689952821
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-543-2b68df72
+Your prepared working directory: /tmp/gh-issue-solver-1760689952821
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 # LinksPlatform ([русская версия](https://github.com/Konard/LinksPlatform/blob/master/README.ru.md))
 
 English version of this README page is moved to [our organization's page](https://github.com/linksplatform).
+
+## [PostgreSQL vs Doublets](https://github.com/linksplatform/Comparisons.PostgreSQLVSDoublets)
+
+Doublets are from 1746 to 15745 times faster than PostgreSQL in write operations, and from 100 to 9694 times faster in read operations.

--- a/README.ru.md
+++ b/README.ru.md
@@ -53,6 +53,10 @@ links.Delete(link);
 
 [![Изображение с результатом сравнения производительности SQLite и Дуплетов.](https://raw.githubusercontent.com/linksplatform/Documentation/master/doc/Examples/sqlite_vs_doublets_performance.png "Результат сравнения производительности SQLite и Дуплетов")](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)
 
+## [PostgreSQL против Дуплетов](https://github.com/linksplatform/Comparisons.PostgreSQLVSDoublets)
+
+Дуплеты работают от 1746 до 15745 раз быстрее PostgreSQL в операциях записи, и от 100 до 9694 раз быстрее в операциях чтения.
+
 ## Описание
 
 Вдохновлено работой Симона Вильямса ([Ассоциативная модель данных - англ.](https://web.archive.org/web/20210814063207/https://en.wikipedia.org/wiki/Associative_model_of_data)), [книга (англ.)](https://web.archive.org/web/20181219134621/http://sentences.com/docs/amd.pdf), [сравнение с реляционными моделями данных (англ.)](http://iacis.org/iis/2009/P2009_1301.pdf).


### PR DESCRIPTION
## Summary

This PR addresses issue #543 by adding a reference to the PostgreSQL vs Doublets comparison in the README files.

## Changes

- Added a new section in `README.md` with a link to the [PostgreSQL vs Doublets comparison repository](https://github.com/linksplatform/Comparisons.PostgreSQLVSDoublets)
- Added a new section in `README.ru.md` with a link to the PostgreSQL comparison repository
- Included performance statistics showing that Doublets are from 1746 to 15745 times faster than PostgreSQL in write operations, and from 100 to 9694 times faster in read operations

## Related Issue

Fixes #543

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)