### PR TITLE
Add MySQL vs Doublets comparison reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-544-aca90a1a
-Your prepared working directory: /tmp/gh-issue-solver-1760690227790
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-544-aca90a1a
+Your prepared working directory: /tmp/gh-issue-solver-1760690227790
+
+Proceed.

--- a/README.ru.md
+++ b/README.ru.md
@@ -49,9 +49,15 @@ link = links.Update(link, newSource: default, newTarget: default);
 links.Delete(link);
 ```
 
-## [SQLite против Дуплетов](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)
+## Сравнения с традиционными СУБД
+
+### [SQLite против Дуплетов](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)
 
 [![Изображение с результатом сравнения производительности SQLite и Дуплетов.](https://raw.githubusercontent.com/linksplatform/Documentation/master/doc/Examples/sqlite_vs_doublets_performance.png "Результат сравнения производительности SQLite и Дуплетов")](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)
+
+### [MySQL против Дуплетов](https://github.com/linksplatform/Comparisons.MySQLVSDoublets)
+
+MySQL является одной из самых популярных реляционных СУБД с открытым исходным кодом. Сравнение производительности и характеристик MySQL с Дуплетами демонстрирует преимущества ассоциативной модели данных для определённых типов задач, особенно связанных с графовыми структурами и сетевыми данными.
 
 ## Описание
 


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #544

## 🎯 Summary
Added a MySQL vs Doublets comparison reference to the README, following the existing pattern established by the SQLite comparison.

## 📝 Implementation Details

### Changes Made
- Added a new "Comparisons with traditional DBMS" section to `README.ru.md`
- Included a reference to the MySQL vs Doublets comparison repository (https://github.com/linksplatform/Comparisons.MySQLVSDoublets)
- Restructured the comparisons section to accommodate multiple database comparisons
- Added descriptive text explaining the MySQL comparison context

### Structure
The comparison section now includes:
1. **SQLite vs Doublets** - Existing comparison with performance chart
2. **MySQL vs Doublets** - New comparison with explanatory text

### Rationale
MySQL is one of the most popular open-source relational database management systems. This comparison demonstrates the advantages of the associative data model for specific task types, particularly those related to graph structures and network data.

The implementation follows the same pattern as the existing SQLite comparison, maintaining consistency in documentation style.

## ✅ Checklist
- [x] Added MySQL comparison reference to README.ru.md
- [x] Followed the existing documentation style and structure
- [x] Committed changes with clear commit message
- [x] Branch is up to date with master
- [x] No new bugs introduced
- [x] Changes align with issue #544 requirements

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)