### PR TITLE
Add JSON schema inference functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-569-1d02e8b1
+Your prepared working directory: /tmp/gh-issue-solver-1760696311615
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-569-1d02e8b1
-Your prepared working directory: /tmp/gh-issue-solver-1760696311615
-
-Proceed.

--- a/Platform/Platform.Examples/JsonSchemaInferrer.cs
+++ b/Platform/Platform.Examples/JsonSchemaInferrer.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Infers a JSON schema from multiple JSON document examples.
+    /// Uses a merge-based approach where individual schemas are inferred and then merged.
+    /// </summary>
+    public class JsonSchemaInferrer
+    {
+        private readonly JsonSchemaInferrerOptions _options;
+
+        public JsonSchemaInferrer() : this(new JsonSchemaInferrerOptions()) { }
+
+        public JsonSchemaInferrer(JsonSchemaInferrerOptions options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <summary>
+        /// Infers a schema from multiple JSON document strings.
+        /// </summary>
+        public JsonSchema InferSchema(IEnumerable<string> jsonDocuments)
+        {
+            if (jsonDocuments == null || !jsonDocuments.Any())
+            {
+                throw new ArgumentException("At least one JSON document is required for schema inference.", nameof(jsonDocuments));
+            }
+
+            JsonSchema mergedSchema = null;
+
+            foreach (var jsonDoc in jsonDocuments)
+            {
+                using var document = JsonDocument.Parse(jsonDoc);
+                var schema = InferSchemaFromElement(document.RootElement);
+
+                mergedSchema = mergedSchema == null ? schema : MergeSchemas(mergedSchema, schema);
+            }
+
+            return mergedSchema;
+        }
+
+        /// <summary>
+        /// Infers schema from a single JSON element.
+        /// </summary>
+        private JsonSchema InferSchemaFromElement(JsonElement element)
+        {
+            var schema = new JsonSchema();
+
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    schema.Type = JsonSchemaType.Object;
+                    schema.Properties = new Dictionary<string, JsonSchema>();
+                    schema.Required = new HashSet<string>();
+
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        schema.Properties[property.Name] = InferSchemaFromElement(property.Value);
+                        schema.Required.Add(property.Name);
+                    }
+                    break;
+
+                case JsonValueKind.Array:
+                    schema.Type = JsonSchemaType.Array;
+                    var itemSchemas = new List<JsonSchema>();
+
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        itemSchemas.Add(InferSchemaFromElement(item));
+                    }
+
+                    // Merge all item schemas to find common structure
+                    if (itemSchemas.Count > 0)
+                    {
+                        schema.Items = itemSchemas[0];
+                        for (int i = 1; i < itemSchemas.Count; i++)
+                        {
+                            schema.Items = MergeSchemas(schema.Items, itemSchemas[i]);
+                        }
+                    }
+                    else
+                    {
+                        // Empty array - default to allowing any type
+                        schema.Items = new JsonSchema { Type = JsonSchemaType.Any };
+                    }
+                    break;
+
+                case JsonValueKind.String:
+                    schema.Type = JsonSchemaType.String;
+                    break;
+
+                case JsonValueKind.Number:
+                    // Determine if integer or number
+                    if (element.TryGetInt64(out _))
+                    {
+                        schema.Type = JsonSchemaType.Integer;
+                    }
+                    else
+                    {
+                        schema.Type = JsonSchemaType.Number;
+                    }
+                    break;
+
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    schema.Type = JsonSchemaType.Boolean;
+                    break;
+
+                case JsonValueKind.Null:
+                    schema.Type = JsonSchemaType.Null;
+                    break;
+
+                default:
+                    schema.Type = JsonSchemaType.Any;
+                    break;
+            }
+
+            return schema;
+        }
+
+        /// <summary>
+        /// Merges two schemas into a single schema that encompasses both.
+        /// </summary>
+        private JsonSchema MergeSchemas(JsonSchema schema1, JsonSchema schema2)
+        {
+            if (schema1 == null) return schema2;
+            if (schema2 == null) return schema1;
+
+            var merged = new JsonSchema();
+
+            // If types are different, create a union type or use "any"
+            if (schema1.Type != schema2.Type)
+            {
+                if (_options.UseUnionTypes)
+                {
+                    merged.Type = JsonSchemaType.Union;
+                    merged.UnionTypes = new HashSet<JsonSchemaType> { schema1.Type, schema2.Type };
+                }
+                else
+                {
+                    merged.Type = JsonSchemaType.Any;
+                }
+                return merged;
+            }
+
+            merged.Type = schema1.Type;
+
+            // Merge based on type
+            switch (merged.Type)
+            {
+                case JsonSchemaType.Object:
+                    merged.Properties = new Dictionary<string, JsonSchema>();
+                    merged.Required = new HashSet<string>();
+
+                    // Merge properties
+                    var allKeys = new HashSet<string>();
+                    if (schema1.Properties != null) allKeys.UnionWith(schema1.Properties.Keys);
+                    if (schema2.Properties != null) allKeys.UnionWith(schema2.Properties.Keys);
+
+                    foreach (var key in allKeys)
+                    {
+                        var hasInSchema1 = schema1.Properties?.ContainsKey(key) ?? false;
+                        var hasInSchema2 = schema2.Properties?.ContainsKey(key) ?? false;
+
+                        if (hasInSchema1 && hasInSchema2)
+                        {
+                            merged.Properties[key] = MergeSchemas(schema1.Properties[key], schema2.Properties[key]);
+
+                            // Property is required only if it's in both schemas
+                            if ((schema1.Required?.Contains(key) ?? false) && (schema2.Required?.Contains(key) ?? false))
+                            {
+                                merged.Required.Add(key);
+                            }
+                        }
+                        else if (hasInSchema1)
+                        {
+                            merged.Properties[key] = schema1.Properties[key];
+                            // Not required since it's not in schema2
+                        }
+                        else if (hasInSchema2)
+                        {
+                            merged.Properties[key] = schema2.Properties[key];
+                            // Not required since it's not in schema1
+                        }
+                    }
+                    break;
+
+                case JsonSchemaType.Array:
+                    if (schema1.Items != null && schema2.Items != null)
+                    {
+                        merged.Items = MergeSchemas(schema1.Items, schema2.Items);
+                    }
+                    else
+                    {
+                        merged.Items = schema1.Items ?? schema2.Items ?? new JsonSchema { Type = JsonSchemaType.Any };
+                    }
+                    break;
+
+                case JsonSchemaType.Integer:
+                case JsonSchemaType.Number:
+                    // If one is integer and being compared with number, promote to number
+                    if ((schema1.Type == JsonSchemaType.Integer && schema2.Type == JsonSchemaType.Number) ||
+                        (schema1.Type == JsonSchemaType.Number && schema2.Type == JsonSchemaType.Integer))
+                    {
+                        merged.Type = JsonSchemaType.Number;
+                    }
+                    break;
+
+                // For primitive types, the types already match, so no additional merging needed
+                case JsonSchemaType.String:
+                case JsonSchemaType.Boolean:
+                case JsonSchemaType.Null:
+                    break;
+            }
+
+            return merged;
+        }
+
+        /// <summary>
+        /// Converts the inferred schema to JSON Schema format (as JSON string).
+        /// </summary>
+        public string ToJsonSchemaString(JsonSchema schema)
+        {
+            var schemaObject = ConvertToJsonSchemaObject(schema);
+            return JsonSerializer.Serialize(schemaObject, new JsonSerializerOptions { WriteIndented = true });
+        }
+
+        private Dictionary<string, object> ConvertToJsonSchemaObject(JsonSchema schema)
+        {
+            var result = new Dictionary<string, object>
+            {
+                ["$schema"] = "http://json-schema.org/draft-07/schema#"
+            };
+
+            AddTypeToSchema(result, schema);
+
+            if (schema.Type == JsonSchemaType.Object && schema.Properties != null && schema.Properties.Count > 0)
+            {
+                var properties = new Dictionary<string, object>();
+                foreach (var prop in schema.Properties)
+                {
+                    var propSchema = new Dictionary<string, object>();
+                    AddTypeToSchema(propSchema, prop.Value);
+
+                    if (prop.Value.Type == JsonSchemaType.Object && prop.Value.Properties != null)
+                    {
+                        propSchema["properties"] = ConvertPropertiesToJsonSchema(prop.Value.Properties);
+                        if (prop.Value.Required != null && prop.Value.Required.Count > 0)
+                        {
+                            propSchema["required"] = prop.Value.Required.ToList();
+                        }
+                    }
+                    else if (prop.Value.Type == JsonSchemaType.Array && prop.Value.Items != null)
+                    {
+                        var itemsSchema = new Dictionary<string, object>();
+                        AddTypeToSchema(itemsSchema, prop.Value.Items);
+                        if (prop.Value.Items.Properties != null)
+                        {
+                            itemsSchema["properties"] = ConvertPropertiesToJsonSchema(prop.Value.Items.Properties);
+                            if (prop.Value.Items.Required != null && prop.Value.Items.Required.Count > 0)
+                            {
+                                itemsSchema["required"] = prop.Value.Items.Required.ToList();
+                            }
+                        }
+                        propSchema["items"] = itemsSchema;
+                    }
+
+                    properties[prop.Key] = propSchema;
+                }
+                result["properties"] = properties;
+
+                if (schema.Required != null && schema.Required.Count > 0)
+                {
+                    result["required"] = schema.Required.ToList();
+                }
+            }
+            else if (schema.Type == JsonSchemaType.Array && schema.Items != null)
+            {
+                var itemsSchema = new Dictionary<string, object>();
+                AddTypeToSchema(itemsSchema, schema.Items);
+                if (schema.Items.Properties != null)
+                {
+                    itemsSchema["properties"] = ConvertPropertiesToJsonSchema(schema.Items.Properties);
+                    if (schema.Items.Required != null && schema.Items.Required.Count > 0)
+                    {
+                        itemsSchema["required"] = schema.Items.Required.ToList();
+                    }
+                }
+                result["items"] = itemsSchema;
+            }
+
+            return result;
+        }
+
+        private Dictionary<string, object> ConvertPropertiesToJsonSchema(Dictionary<string, JsonSchema> properties)
+        {
+            var result = new Dictionary<string, object>();
+            foreach (var prop in properties)
+            {
+                result[prop.Key] = ConvertToJsonSchemaObject(prop.Value);
+            }
+            return result;
+        }
+
+        private void AddTypeToSchema(Dictionary<string, object> schemaDict, JsonSchema schema)
+        {
+            if (schema.Type == JsonSchemaType.Union && schema.UnionTypes != null)
+            {
+                schemaDict["type"] = schema.UnionTypes.Select(t => t.ToString().ToLowerInvariant()).ToArray();
+            }
+            else
+            {
+                schemaDict["type"] = schema.Type.ToString().ToLowerInvariant();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Options for schema inference.
+    /// </summary>
+    public class JsonSchemaInferrerOptions
+    {
+        /// <summary>
+        /// If true, uses union types when types differ. If false, uses "any" type.
+        /// Default: true
+        /// </summary>
+        public bool UseUnionTypes { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Represents an inferred JSON schema.
+    /// </summary>
+    public class JsonSchema
+    {
+        public JsonSchemaType Type { get; set; }
+        public Dictionary<string, JsonSchema> Properties { get; set; }
+        public HashSet<string> Required { get; set; }
+        public JsonSchema Items { get; set; }
+        public HashSet<JsonSchemaType> UnionTypes { get; set; }
+    }
+
+    /// <summary>
+    /// JSON schema types.
+    /// </summary>
+    public enum JsonSchemaType
+    {
+        Object,
+        Array,
+        String,
+        Number,
+        Integer,
+        Boolean,
+        Null,
+        Any,
+        Union
+    }
+}

--- a/Platform/Platform.Examples/JsonSchemaInferrerCLI.cs
+++ b/Platform/Platform.Examples/JsonSchemaInferrerCLI.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Platform.Examples
+{
+    /// <summary>
+    /// Command-line interface for JSON schema inference.
+    /// </summary>
+    public class JsonSchemaInferrerCLI : ICommandLineInterface
+    {
+        public void Run(params string[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                PrintUsage();
+                return;
+            }
+
+            var command = args[0].ToLowerInvariant();
+
+            switch (command)
+            {
+                case "infer":
+                    InferSchemaCommand(args.Skip(1).ToArray());
+                    break;
+
+                case "help":
+                case "-h":
+                case "--help":
+                    PrintUsage();
+                    break;
+
+                default:
+                    Console.WriteLine($"Unknown command: {command}");
+                    PrintUsage();
+                    break;
+            }
+        }
+
+        private void InferSchemaCommand(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Error: No input files or JSON strings provided.");
+                Console.WriteLine("Usage: infer <file1> [file2] [file3] ... [-o <output-file>] [--use-any]");
+                return;
+            }
+
+            var files = new List<string>();
+            string outputFile = null;
+            bool useUnionTypes = true;
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "-o" || args[i] == "--output")
+                {
+                    if (i + 1 < args.Length)
+                    {
+                        outputFile = args[++i];
+                    }
+                    else
+                    {
+                        Console.WriteLine("Error: -o flag requires an output file path.");
+                        return;
+                    }
+                }
+                else if (args[i] == "--use-any")
+                {
+                    useUnionTypes = false;
+                }
+                else
+                {
+                    files.Add(args[i]);
+                }
+            }
+
+            if (files.Count == 0)
+            {
+                Console.WriteLine("Error: No input files provided.");
+                return;
+            }
+
+            try
+            {
+                var jsonDocuments = new List<string>();
+
+                foreach (var file in files)
+                {
+                    if (!File.Exists(file))
+                    {
+                        Console.WriteLine($"Warning: File not found: {file}");
+                        continue;
+                    }
+
+                    var content = File.ReadAllText(file);
+                    jsonDocuments.Add(content);
+                    Console.WriteLine($"Loaded: {file}");
+                }
+
+                if (jsonDocuments.Count == 0)
+                {
+                    Console.WriteLine("Error: No valid JSON files loaded.");
+                    return;
+                }
+
+                Console.WriteLine($"\nInferring schema from {jsonDocuments.Count} document(s)...");
+
+                var inferrer = new JsonSchemaInferrer(new JsonSchemaInferrerOptions
+                {
+                    UseUnionTypes = useUnionTypes
+                });
+
+                var schema = inferrer.InferSchema(jsonDocuments);
+                var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+                if (outputFile != null)
+                {
+                    File.WriteAllText(outputFile, schemaJson);
+                    Console.WriteLine($"\nSchema written to: {outputFile}");
+                }
+                else
+                {
+                    Console.WriteLine("\nInferred JSON Schema:");
+                    Console.WriteLine(schemaJson);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                if (ex.InnerException != null)
+                {
+                    Console.WriteLine($"Inner exception: {ex.InnerException.Message}");
+                }
+            }
+        }
+
+        private void PrintUsage()
+        {
+            Console.WriteLine("JSON Schema Inferrer - Infer JSON schema from multiple JSON documents");
+            Console.WriteLine();
+            Console.WriteLine("Usage:");
+            Console.WriteLine("  infer <file1> [file2] [file3] ... [-o <output-file>] [--use-any]");
+            Console.WriteLine();
+            Console.WriteLine("Commands:");
+            Console.WriteLine("  infer           Infer schema from JSON files");
+            Console.WriteLine("  help            Display this help message");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  -o, --output    Output file for the inferred schema (optional)");
+            Console.WriteLine("  --use-any       Use 'any' type instead of union types for conflicting types");
+            Console.WriteLine();
+            Console.WriteLine("Examples:");
+            Console.WriteLine("  infer doc1.json doc2.json doc3.json");
+            Console.WriteLine("  infer doc1.json doc2.json -o schema.json");
+            Console.WriteLine("  infer *.json --use-any -o inferred-schema.json");
+        }
+    }
+}

--- a/Platform/Platform.Examples/Platform.Examples.csproj
+++ b/Platform/Platform.Examples/Platform.Examples.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>git://github.com/Konard/LinksPlatform</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +26,7 @@
     <PackageReference Include="Platform.Counters" Version="0.0.2" />
     <PackageReference Include="Platform.Communication" Version="0.2.0" />
     <PackageReference Include="Platform.Data.Doublets" Version="0.6.10" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
 </Project>

--- a/Platform/Platform.Examples/Platform.Examples.csproj
+++ b/Platform/Platform.Examples/Platform.Examples.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Platform.Counters" Version="0.0.2" />
     <PackageReference Include="Platform.Communication" Version="0.2.0" />
     <PackageReference Include="Platform.Data.Doublets" Version="0.6.10" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,64 @@
+# JSON Schema Inference Examples
+
+This directory contains example JSON documents and test scripts for demonstrating the JSON schema inference functionality.
+
+## Sample JSON Documents
+
+- `sample1.json` - User document with basic fields
+- `sample2.json` - User document with additional optional fields
+- `sample3.json` - User document demonstrating common required fields
+
+## Test Script
+
+- `test-schema-inference.cs` - C# test program demonstrating various schema inference scenarios
+
+## Usage Example
+
+To infer a schema from the sample documents using the CLI:
+
+```bash
+# Build the project first
+cd Platform
+dotnet build
+
+# Run schema inference on sample documents
+dotnet run --project Platform.Examples -- infer ../examples/sample1.json ../examples/sample2.json ../examples/sample3.json -o ../examples/inferred-schema.json
+```
+
+## Expected Output
+
+The inferred schema will identify:
+- Common required fields (id, name, email, age, isActive, address, tags)
+- Optional fields (phone, address.country)
+- Proper types for all fields
+- Nested object structures
+- Array element types
+
+Example inferred schema structure:
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": { "type": "integer" },
+    "name": { "type": "string" },
+    "email": { "type": "string" },
+    "age": { "type": "integer" },
+    "isActive": { "type": "boolean" },
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" },
+        "zipCode": { "type": "string" }
+      },
+      "required": ["street", "city", "zipCode"]
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["id", "name", "email", "age", "isActive", "address", "tags"]
+}
+```

--- a/examples/sample1.json
+++ b/examples/sample1.json
@@ -1,0 +1,13 @@
+{
+  "id": 1,
+  "name": "John Doe",
+  "email": "john@example.com",
+  "age": 30,
+  "isActive": true,
+  "address": {
+    "street": "123 Main St",
+    "city": "New York",
+    "zipCode": "10001"
+  },
+  "tags": ["developer", "engineer"]
+}

--- a/examples/sample2.json
+++ b/examples/sample2.json
@@ -1,0 +1,15 @@
+{
+  "id": 2,
+  "name": "Jane Smith",
+  "email": "jane@example.com",
+  "age": 28,
+  "isActive": false,
+  "address": {
+    "street": "456 Oak Ave",
+    "city": "Los Angeles",
+    "zipCode": "90001",
+    "country": "USA"
+  },
+  "tags": ["designer", "manager"],
+  "phone": "555-1234"
+}

--- a/examples/sample3.json
+++ b/examples/sample3.json
@@ -1,0 +1,13 @@
+{
+  "id": 3,
+  "name": "Bob Johnson",
+  "email": "bob@example.com",
+  "age": 35,
+  "isActive": true,
+  "address": {
+    "street": "789 Pine Rd",
+    "city": "Chicago",
+    "zipCode": "60601"
+  },
+  "tags": ["architect"]
+}

--- a/examples/test-schema-inference.cs
+++ b/examples/test-schema-inference.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Platform.Examples;
+
+namespace SchemaInferenceTest
+{
+    /// <summary>
+    /// Test script to demonstrate and verify JSON schema inference functionality.
+    /// This script can be run to test the schema inference algorithm with sample data.
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("=== JSON Schema Inference Test ===\n");
+
+            // Test 1: Simple schema inference from multiple documents
+            Test1_BasicSchemaInference();
+
+            // Test 2: Schema inference with optional fields
+            Test2_OptionalFields();
+
+            // Test 3: Schema inference with arrays
+            Test3_ArrayHandling();
+
+            // Test 4: Schema inference with type conflicts
+            Test4_TypeConflicts();
+
+            // Test 5: Schema inference with nested objects
+            Test5_NestedObjects();
+
+            Console.WriteLine("\n=== All Tests Completed ===");
+        }
+
+        static void Test1_BasicSchemaInference()
+        {
+            Console.WriteLine("Test 1: Basic Schema Inference");
+            Console.WriteLine("--------------------------------");
+
+            var json1 = @"{""name"": ""John"", ""age"": 30}";
+            var json2 = @"{""name"": ""Jane"", ""age"": 25}";
+
+            var inferrer = new JsonSchemaInferrer();
+            var schema = inferrer.InferSchema(new[] { json1, json2 });
+            var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+            Console.WriteLine("Input documents:");
+            Console.WriteLine(json1);
+            Console.WriteLine(json2);
+            Console.WriteLine("\nInferred schema:");
+            Console.WriteLine(schemaJson);
+            Console.WriteLine();
+        }
+
+        static void Test2_OptionalFields()
+        {
+            Console.WriteLine("Test 2: Optional Fields");
+            Console.WriteLine("------------------------");
+
+            var json1 = @"{""id"": 1, ""name"": ""John"", ""email"": ""john@example.com""}";
+            var json2 = @"{""id"": 2, ""name"": ""Jane""}";
+
+            var inferrer = new JsonSchemaInferrer();
+            var schema = inferrer.InferSchema(new[] { json1, json2 });
+            var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+            Console.WriteLine("Input documents:");
+            Console.WriteLine(json1);
+            Console.WriteLine(json2);
+            Console.WriteLine("\nInferred schema (email should not be required):");
+            Console.WriteLine(schemaJson);
+            Console.WriteLine();
+        }
+
+        static void Test3_ArrayHandling()
+        {
+            Console.WriteLine("Test 3: Array Handling");
+            Console.WriteLine("----------------------");
+
+            var json1 = @"{""items"": [1, 2, 3]}";
+            var json2 = @"{""items"": [4, 5]}";
+
+            var inferrer = new JsonSchemaInferrer();
+            var schema = inferrer.InferSchema(new[] { json1, json2 });
+            var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+            Console.WriteLine("Input documents:");
+            Console.WriteLine(json1);
+            Console.WriteLine(json2);
+            Console.WriteLine("\nInferred schema:");
+            Console.WriteLine(schemaJson);
+            Console.WriteLine();
+        }
+
+        static void Test4_TypeConflicts()
+        {
+            Console.WriteLine("Test 4: Type Conflicts");
+            Console.WriteLine("----------------------");
+
+            var json1 = @"{""value"": 123}";
+            var json2 = @"{""value"": ""text""}";
+
+            var inferrer = new JsonSchemaInferrer(new JsonSchemaInferrerOptions { UseUnionTypes = true });
+            var schema = inferrer.InferSchema(new[] { json1, json2 });
+            var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+            Console.WriteLine("Input documents:");
+            Console.WriteLine(json1);
+            Console.WriteLine(json2);
+            Console.WriteLine("\nInferred schema (with union types):");
+            Console.WriteLine(schemaJson);
+            Console.WriteLine();
+        }
+
+        static void Test5_NestedObjects()
+        {
+            Console.WriteLine("Test 5: Nested Objects");
+            Console.WriteLine("-----------------------");
+
+            var json1 = @"{""user"": {""name"": ""John"", ""age"": 30}, ""status"": ""active""}";
+            var json2 = @"{""user"": {""name"": ""Jane"", ""age"": 25}, ""status"": ""inactive""}";
+
+            var inferrer = new JsonSchemaInferrer();
+            var schema = inferrer.InferSchema(new[] { json1, json2 });
+            var schemaJson = inferrer.ToJsonSchemaString(schema);
+
+            Console.WriteLine("Input documents:");
+            Console.WriteLine(json1);
+            Console.WriteLine(json2);
+            Console.WriteLine("\nInferred schema:");
+            Console.WriteLine(schemaJson);
+            Console.WriteLine();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive JSON schema inference algorithm that can analyze multiple JSON document examples and infer a unified schema from them.

### Implementation Details

**Core Algorithm (`JsonSchemaInferrer.cs`):**
- Infers schema types: object, array, string, number, integer, boolean, null
- Merges schemas from multiple documents to find common structure
- Handles nested objects and arrays recursively
- Identifies required vs optional fields (a field is required only if present in all documents)
- Supports union types for conflicting field types (configurable)
- Generates JSON Schema draft-07 compliant output

**Key Features:**
- **Type inference**: Automatically detects data types including distinguishing integers from floating-point numbers
- **Schema merging**: Intelligently combines schemas from multiple examples
- **Optional field detection**: Fields present in some but not all documents are marked as optional
- **Nested structure support**: Handles arbitrarily deep nesting of objects and arrays
- **Array element unification**: Infers common schema for array elements across all examples
- **Configurable behavior**: Option to use union types vs "any" type for conflicting types

**CLI Interface (`JsonSchemaInferrerCLI.cs`):**
- Command-line tool for easy schema inference
- Supports multiple input files
- Optional output file specification
- Configurable union type behavior

**Example Usage:**
```bash
# Infer schema from multiple JSON files
dotnet run --project Platform.Examples -- infer sample1.json sample2.json sample3.json -o schema.json

# Use "any" type instead of union types for conflicts
dotnet run --project Platform.Examples -- infer *.json --use-any -o schema.json
```

### Files Added/Modified

**New Files:**
- `Platform/Platform.Examples/JsonSchemaInferrer.cs` - Core inference algorithm
- `Platform/Platform.Examples/JsonSchemaInferrerCLI.cs` - Command-line interface
- `examples/sample1.json`, `sample2.json`, `sample3.json` - Example JSON documents
- `examples/test-schema-inference.cs` - Test script demonstrating various scenarios
- `examples/README.md` - Documentation and usage examples

**Modified Files:**
- `Platform/Platform.Examples/Platform.Examples.csproj` - Added System.Text.Json dependency and C# 8.0 language version

### Test Plan

✅ Built successfully locally
✅ CI passing
✅ Example JSON documents provided
✅ Test script with multiple scenarios included

The implementation handles:
- Simple flat objects
- Nested objects and arrays
- Optional fields
- Type conflicts
- Empty arrays
- Multiple document merging

### Algorithm Approach

The implementation follows a MapReduce-style approach based on recent research:
1. **Infer**: Generate a schema for each individual JSON document
2. **Merge**: Hierarchically merge schemas to create a unified schema
3. **Output**: Generate JSON Schema draft-07 compliant format

This approach is inspired by work from Baazizi et al. on parametric schema inference for massive JSON datasets, adapted for the LinksPlatform ecosystem.

Fixes #569

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>