### PR TITLE
Update README to reference Documentation repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-576-a919a880
+Your prepared working directory: /tmp/gh-issue-solver-1760697460617
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-576-a919a880
-Your prepared working directory: /tmp/gh-issue-solver-1760697460617
-
-Proceed.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 # LinksPlatform ([русская версия](https://github.com/Konard/LinksPlatform/blob/master/README.ru.md))
 
-English version of this README page is moved to [our organization's page](https://github.com/linksplatform).
+English version of this README page and wiki pages are moved to [our Documentation repository](https://github.com/linksplatform/Documentation).
+
+For the full platform overview and packages, visit [our organization's page](https://github.com/linksplatform).


### PR DESCRIPTION
## Summary

This pull request resolves issue #576 by updating the README.md to clearly direct users to the [Documentation repository](https://github.com/linksplatform/Documentation), as suggested by @konard in the issue discussion.

## Changes Made

- Updated `README.md` to explicitly mention that README and wiki pages have been moved to the Documentation repository
- Added clear link to the Documentation repository for users looking for comprehensive documentation
- Maintained reference to the organization page for package information

## Context

In issue #576, there was a discussion about whether to delete certain repositories to make room. The repository owner (@konard) decided that **no repositories should be removed**. Instead, the solution is to consolidate documentation in the existing Documentation repository and update this README to point users there.

This approach:
- Preserves all existing repositories
- Provides clear navigation for users seeking documentation
- Centralizes documentation in the dedicated Documentation repository

## Fixes

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)