### PR TITLE
Add Discord bot for automated error message search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,8 @@ Platform/Platform.Data.Kernel/*.dll
 
 # Platform.Data ~ Links Database files
 *.links
+
+# Discord Bot Configuration
+Platform/Platform.Data.DiscordBot/appsettings.json
+Platform/Platform.Data.DiscordBot/appsettings.*.json
+!Platform/Platform.Data.DiscordBot/appsettings.Development.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-673-fd0a9ba2
-Your prepared working directory: /tmp/gh-issue-solver-1760705920361
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-673-fd0a9ba2
+Your prepared working directory: /tmp/gh-issue-solver-1760705920361
+
+Proceed.

--- a/Platform/Platform.Data.DiscordBot/DiscordBot.cs
+++ b/Platform/Platform.Data.DiscordBot/DiscordBot.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+
+namespace Platform.Data.DiscordBot
+{
+    /// <summary>
+    /// Discord bot that automates error message search across multiple platforms
+    /// </summary>
+    public class DiscordBot
+    {
+        private readonly DiscordSocketClient _client;
+        private readonly string _botToken;
+
+        public DiscordBot(string botToken)
+        {
+            if (string.IsNullOrWhiteSpace(botToken))
+            {
+                throw new ArgumentException("Bot token cannot be empty", nameof(botToken));
+            }
+
+            _botToken = botToken;
+
+            var config = new DiscordSocketConfig
+            {
+                GatewayIntents = GatewayIntents.Guilds |
+                                 GatewayIntents.GuildMessages |
+                                 GatewayIntents.MessageContent
+            };
+
+            _client = new DiscordSocketClient(config);
+            _client.Log += LogAsync;
+            _client.Ready += ReadyAsync;
+            _client.SlashCommandExecuted += SlashCommandHandler;
+            _client.MessageReceived += MessageReceivedAsync;
+        }
+
+        private Task LogAsync(LogMessage log)
+        {
+            Console.WriteLine(log.ToString());
+            return Task.CompletedTask;
+        }
+
+        private Task ReadyAsync()
+        {
+            Console.WriteLine($"Bot is connected as {_client.CurrentUser}");
+            return Task.CompletedTask;
+        }
+
+        private async Task MessageReceivedAsync(SocketMessage message)
+        {
+            // Ignore bot messages
+            if (message.Author.IsBot)
+                return;
+
+            // Check if the message starts with !search or !error
+            if (message.Content.StartsWith("!search ") || message.Content.StartsWith("!error "))
+            {
+                var errorMessage = message.Content.Substring(message.Content.IndexOf(' ') + 1);
+                var searchLinks = SearchLinkGenerator.GenerateCompactSearchLinks(errorMessage);
+
+                await message.Channel.SendMessageAsync(searchLinks);
+            }
+            // Check if message starts with !help
+            else if (message.Content.Equals("!help", StringComparison.OrdinalIgnoreCase) ||
+                     message.Content.Equals("!search", StringComparison.OrdinalIgnoreCase))
+            {
+                var helpMessage = @"**Error Search Bot Help**
+
+Use this bot to quickly generate search links for error messages across multiple platforms.
+
+**Commands:**
+• `!search <error message>` - Generate search links for an error message
+• `!error <error message>` - Same as !search
+• `/search <error message>` - Slash command version (if registered)
+• `!help` - Show this help message
+
+**Example:**
+```
+!search NullReferenceException: Object reference not set to an instance of an object
+```
+
+The bot will generate search links for:
+🌐 Google
+🔷 Bing
+💻 GitHub Code Search
+📝 GitHub Issues Search";
+
+                await message.Channel.SendMessageAsync(helpMessage);
+            }
+        }
+
+        private async Task SlashCommandHandler(SocketSlashCommand command)
+        {
+            if (command.CommandName == "search")
+            {
+                var errorMessage = command.Data.Options.FirstOrDefault()?.Value?.ToString();
+
+                if (string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    await command.RespondAsync("Please provide an error message to search for.");
+                    return;
+                }
+
+                var searchLinks = SearchLinkGenerator.GenerateCompactSearchLinks(errorMessage);
+                await command.RespondAsync(searchLinks);
+            }
+        }
+
+        /// <summary>
+        /// Starts the Discord bot
+        /// </summary>
+        public async Task StartAsync()
+        {
+            await _client.LoginAsync(TokenType.Bot, _botToken);
+            await _client.StartAsync();
+
+            // Register slash commands
+            try
+            {
+                var searchCommand = new SlashCommandBuilder()
+                    .WithName("search")
+                    .WithDescription("Search for an error message across multiple platforms")
+                    .AddOption("error", ApplicationCommandOptionType.String,
+                              "The error message to search for", isRequired: true);
+
+                await _client.CreateGlobalApplicationCommandAsync(searchCommand.Build());
+                Console.WriteLine("Slash command registered successfully");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to register slash command: {ex.Message}");
+            }
+
+            // Keep the bot running
+            await Task.Delay(-1);
+        }
+
+        /// <summary>
+        /// Stops the Discord bot
+        /// </summary>
+        public async Task StopAsync()
+        {
+            await _client.LogoutAsync();
+            await _client.StopAsync();
+        }
+    }
+}

--- a/Platform/Platform.Data.DiscordBot/Platform.Data.DiscordBot.csproj
+++ b/Platform/Platform.Data.DiscordBot/Platform.Data.DiscordBot.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Description>Discord bot for automated error message search</Description>
+    <Copyright>Konstantin Diachenko</Copyright>
+    <AssemblyTitle>Platform.Data.DiscordBot</AssemblyTitle>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <Authors>Konstantin Diachenko</Authors>
+    <AssemblyName>Platform.Data.DiscordBot</AssemblyName>
+    <PackageId>Platform.Data.DiscordBot</PackageId>
+    <PackageTags>LinksPlatform;Discord;Bot;ErrorSearch</PackageTags>
+    <PackageProjectUrl>https://github.com/Konard/LinksPlatform</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/Konard/LinksPlatform/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/Konard/LinksPlatform</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Discord.Net" Version="3.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Platform/Platform.Data.DiscordBot/Program.cs
+++ b/Platform/Platform.Data.DiscordBot/Program.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace Platform.Data.DiscordBot
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            Console.WriteLine("LinksPlatform Discord Error Search Bot");
+            Console.WriteLine("======================================");
+
+            // Load configuration
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            // Get bot token from configuration or environment variable
+            var botToken = configuration["DiscordBotToken"] ?? Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN");
+
+            if (string.IsNullOrWhiteSpace(botToken))
+            {
+                Console.WriteLine("Error: Discord bot token not found!");
+                Console.WriteLine("Please set the DISCORD_BOT_TOKEN environment variable or add it to appsettings.json");
+                Console.WriteLine();
+                Console.WriteLine("Usage:");
+                Console.WriteLine("  Linux/macOS: export DISCORD_BOT_TOKEN=your_token_here");
+                Console.WriteLine("  Windows: set DISCORD_BOT_TOKEN=your_token_here");
+                Console.WriteLine("  appsettings.json: { \"DiscordBotToken\": \"your_token_here\" }");
+                return;
+            }
+
+            try
+            {
+                var bot = new DiscordBot(botToken);
+                Console.WriteLine("Starting bot...");
+                await bot.StartAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error starting bot: {ex.Message}");
+                Console.WriteLine(ex.StackTrace);
+            }
+        }
+    }
+}

--- a/Platform/Platform.Data.DiscordBot/README.md
+++ b/Platform/Platform.Data.DiscordBot/README.md
@@ -1,0 +1,100 @@
+# Discord Error Search Bot
+
+A Discord bot that automates error message search across multiple platforms: Google, Bing, GitHub Code Search, and GitHub Issues Search.
+
+## Features
+
+- 🔍 Generates search links for error messages across multiple platforms
+- 💬 Supports both text commands and slash commands
+- 📝 Respects Discord's 2000 character message limit
+- 🚀 Easy to deploy and configure
+
+## Setup
+
+### Prerequisites
+
+- .NET 6.0 or higher
+- A Discord bot token (see [Discord Developer Portal](https://discord.com/developers/applications))
+
+### Configuration
+
+1. Create a Discord bot at the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Enable the following bot permissions:
+   - Send Messages
+   - Use Slash Commands
+   - Read Messages/View Channels
+3. Enable the following privileged gateway intents:
+   - Message Content Intent
+4. Copy your bot token
+5. Set the bot token using one of these methods:
+
+#### Option 1: Environment Variable
+```bash
+# Linux/macOS
+export DISCORD_BOT_TOKEN=your_token_here
+
+# Windows
+set DISCORD_BOT_TOKEN=your_token_here
+```
+
+#### Option 2: Configuration File
+Edit `appsettings.json`:
+```json
+{
+  "DiscordBotToken": "your_token_here"
+}
+```
+
+### Running the Bot
+
+```bash
+cd Platform/Platform.Data.DiscordBot
+dotnet run
+```
+
+## Usage
+
+### Text Commands
+
+- `!search <error message>` - Generate search links for an error message
+- `!error <error message>` - Same as !search
+- `!help` - Show help message
+
+### Slash Commands
+
+- `/search <error message>` - Generate search links (slash command version)
+
+### Examples
+
+```
+!search NullReferenceException: Object reference not set to an instance of an object
+```
+
+```
+/search TypeError: Cannot read property 'length' of undefined
+```
+
+The bot will respond with search links for:
+- 🌐 Google
+- 🔷 Bing
+- 💻 GitHub Code Search
+- 📝 GitHub Issues Search
+
+## Development
+
+### Building
+
+```bash
+dotnet build Platform/Platform.Data.DiscordBot/Platform.Data.DiscordBot.csproj
+```
+
+### Project Structure
+
+- `Program.cs` - Entry point and configuration loading
+- `DiscordBot.cs` - Main bot logic and command handlers
+- `SearchLinkGenerator.cs` - Search link generation utility
+- `appsettings.json` - Configuration file (optional)
+
+## License
+
+This project is part of the LinksPlatform and is licensed under the same terms.

--- a/Platform/Platform.Data.DiscordBot/SearchLinkGenerator.cs
+++ b/Platform/Platform.Data.DiscordBot/SearchLinkGenerator.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Text;
+using System.Web;
+
+namespace Platform.Data.DiscordBot
+{
+    /// <summary>
+    /// Generates search links for error messages across multiple search engines and platforms
+    /// </summary>
+    public class SearchLinkGenerator
+    {
+        /// <summary>
+        /// Generates search links for the given error message
+        /// </summary>
+        /// <param name="errorMessage">The error message to search for</param>
+        /// <returns>A formatted string containing all search links</returns>
+        public static string GenerateSearchLinks(string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                return "Error: Please provide an error message to search for.";
+            }
+
+            var encodedQuery = Uri.EscapeDataString(errorMessage);
+            var sb = new StringBuilder();
+
+            sb.AppendLine("🔍 **Error Search Links**");
+            sb.AppendLine();
+            sb.AppendLine($"**Query:** `{errorMessage}`");
+            sb.AppendLine();
+
+            // Google Search
+            sb.AppendLine($"🌐 **Google:** https://www.google.com/search?q={encodedQuery}");
+
+            // Bing Search
+            sb.AppendLine($"🔷 **Bing:** https://www.bing.com/search?q={encodedQuery}");
+
+            // GitHub Code Search
+            sb.AppendLine($"💻 **GitHub Code:** https://github.com/search?type=code&q={encodedQuery}");
+
+            // GitHub Issues Search
+            sb.AppendLine($"📝 **GitHub Issues:** https://github.com/search?type=issues&q={encodedQuery}");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Generates a compact version of search links that fits within Discord's character limit
+        /// </summary>
+        /// <param name="errorMessage">The error message to search for</param>
+        /// <param name="maxLength">Maximum length of the response (default: 2000 for Discord)</param>
+        /// <returns>A formatted string containing search links</returns>
+        public static string GenerateCompactSearchLinks(string errorMessage, int maxLength = 2000)
+        {
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                return "Error: Please provide an error message to search for.";
+            }
+
+            // Truncate error message if it's too long
+            var displayMessage = errorMessage.Length > 100
+                ? errorMessage.Substring(0, 97) + "..."
+                : errorMessage;
+
+            var encodedQuery = Uri.EscapeDataString(errorMessage);
+            var sb = new StringBuilder();
+
+            sb.AppendLine("🔍 **Error Search Links**");
+            sb.AppendLine($"`{displayMessage}`");
+            sb.AppendLine();
+
+            // Google
+            var googleLink = $"https://www.google.com/search?q={encodedQuery}";
+            sb.AppendLine($"[Google]({googleLink})");
+
+            // Bing
+            var bingLink = $"https://www.bing.com/search?q={encodedQuery}";
+            sb.AppendLine($"[Bing]({bingLink})");
+
+            // GitHub Code
+            var ghCodeLink = $"https://github.com/search?type=code&q={encodedQuery}";
+            sb.AppendLine($"[GitHub Code]({ghCodeLink})");
+
+            // GitHub Issues
+            var ghIssuesLink = $"https://github.com/search?type=issues&q={encodedQuery}";
+            sb.AppendLine($"[GitHub Issues]({ghIssuesLink})");
+
+            var result = sb.ToString();
+
+            // If still too long, use ultra-compact format
+            if (result.Length > maxLength)
+            {
+                sb.Clear();
+                sb.AppendLine("🔍 Search Links:");
+                sb.AppendLine($"G: {googleLink}");
+                sb.AppendLine($"B: {bingLink}");
+                sb.AppendLine($"GHC: {ghCodeLink}");
+                sb.AppendLine($"GHI: {ghIssuesLink}");
+                result = sb.ToString();
+            }
+
+            return result;
+        }
+    }
+}

--- a/Platform/Platform.sln
+++ b/Platform/Platform.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.MasterServer"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.ConsoleTerminal", "Platform.Data.ConsoleTerminal\Platform.Data.ConsoleTerminal.csproj", "{85D097CE-614E-4351-920B-45BD35AE5A84}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.Data.DiscordBot", "Platform.Data.DiscordBot\Platform.Data.DiscordBot.csproj", "{B1E3C4D5-6F7A-4B8C-9D0E-1F2A3B4C5D6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85D097CE-614E-4351-920B-45BD35AE5A84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E3C4D5-6F7A-4B8C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1E3C4D5-6F7A-4B8C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E3C4D5-6F7A-4B8C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1E3C4D5-6F7A-4B8C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

This PR implements a Discord bot that automates error message search across multiple platforms, solving issue #673.

### What it does

The bot generates search links for error messages across:
- 🌐 Google
- 🔷 Bing  
- 💻 GitHub Code Search
- 📝 GitHub Issues Search

### Features

✅ Text commands: `!search <error>` and `!error <error>`
✅ Slash commands: `/search <error>`
✅ Help command: `!help`
✅ Respects Discord's 2000 character message limit
✅ Easy configuration via environment variables or config file
✅ Built with Discord.Net for .NET 8.0

### Implementation Details

**New Project:** `Platform.Data.DiscordBot`

**Main Components:**
- `SearchLinkGenerator.cs` - Generates search URLs for multiple platforms
- `DiscordBot.cs` - Main bot logic with command handlers
- `Program.cs` - Entry point and configuration loading
- `README.md` - Setup and usage documentation

**Configuration:**
- Bot token can be set via `DISCORD_BOT_TOKEN` environment variable
- Alternative: `appsettings.json` file (ignored by git for security)

### Setup Instructions

1. Create a Discord bot at [Discord Developer Portal](https://discord.com/developers/applications)
2. Enable Message Content Intent
3. Set bot token:
   ```bash
   export DISCORD_BOT_TOKEN=your_token_here
   ```
4. Run the bot:
   ```bash
   cd Platform/Platform.Data.DiscordBot
   dotnet run
   ```

### Example Usage

```
!search NullReferenceException: Object reference not set to an instance of an object
```

The bot responds with clickable search links for all platforms.

### Testing

✅ Code compiles without errors
✅ All dependencies resolved correctly
✅ Added to solution file for integration

## Fixes

Closes #673

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)